### PR TITLE
Adding name for Sources

### DIFF
--- a/dplace_app/load.py
+++ b/dplace_app/load.py
@@ -10,13 +10,14 @@ from load.society_binford import *
 from load.geographic import *
 from load.tree import *
 from load.variables import *
+from load.sources import *
 
 LOAD_BY_ROW=('iso', 'env_vals',
              'langs', 'iso_lat_long',
              'soc_lat_long',
              'ea_soc', 'ea_vars', 'ea_vals',
              'bf_soc', 'bf_vars', 'bf_vals',
-             'bf_harm', 'vars', 'ea_stacked', 'vars')
+             'vars', 'ea_stacked', 'vars')
 
 def run(file_name=None, mode=None):
     if mode == 'geo':
@@ -51,8 +52,6 @@ def run(file_name=None, mode=None):
                         load_lang(dict_row)
                     elif mode == 'bf_soc':
                         load_bf_society(dict_row)
-                    elif mode == 'bf_harm':
-                        load_bf_harm(dict_row)
                     elif mode == 'bf_vars':
                         load_bf_var(dict_row)
                     elif mode == 'bf_vals':

--- a/dplace_app/load/sources.py
+++ b/dplace_app/load/sources.py
@@ -16,6 +16,8 @@ def get_source(source='EA'):
                 focal_year='',
                 subcase='',
             )
+        o.name = "Ethnographic Atlas"
+        o.save()
     elif source == 'Binford':
         try:
             o = Source.objects.get(year="2001", author="Binford")
@@ -27,6 +29,8 @@ def get_source(source='EA'):
                 focal_year='',
                 subcase='',
             )
+        o.name = "Binford Hunter-Gatherer"
+        o.save()
     else:
         raise ValueError("Unknown Source: %s" % source)
     _SOURCE_CACHE[source] = o

--- a/dplace_app/migrations/0056_auto__add_field_source_name.py
+++ b/dplace_app/migrations/0056_auto__add_field_source_name.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Source.name'
+        db.add_column(u'dplace_app_source', 'name',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=100),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Source.name'
+        db.delete_column(u'dplace_app_source', 'name')
+
+
+    models = {
+        u'dplace_app.environmental': {
+            'Meta': {'object_name': 'Environmental'},
+            'actual_location': ('django.contrib.gis.db.models.fields.PointField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'environmentals'", 'null': 'True', 'to': u"orm['dplace_app.ISOCode']"}),
+            'reported_location': ('django.contrib.gis.db.models.fields.PointField', [], {}),
+            'society': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'environmentals'", 'null': 'True', 'to': u"orm['dplace_app.Society']"}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.Source']", 'null': 'True'})
+        },
+        u'dplace_app.environmentalcategory': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'EnvironmentalCategory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30', 'db_index': 'True'})
+        },
+        u'dplace_app.environmentalvalue': {
+            'Meta': {'ordering': "('variable',)", 'unique_together': "(('variable', 'environmental'),)", 'object_name': 'EnvironmentalValue', 'index_together': "[['variable', 'value']]"},
+            'environmental': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'values'", 'to': u"orm['dplace_app.Environmental']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.Source']", 'null': 'True'}),
+            'value': ('django.db.models.fields.FloatField', [], {'db_index': 'True'}),
+            'variable': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'values'", 'to': u"orm['dplace_app.EnvironmentalVariable']"})
+        },
+        u'dplace_app.environmentalvariable': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'EnvironmentalVariable'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.EnvironmentalCategory']", 'null': 'True'}),
+            'codebook_info': ('django.db.models.fields.CharField', [], {'default': "'None'", 'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'units': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'dplace_app.geographicregion': {
+            'Meta': {'object_name': 'GeographicRegion'},
+            'continent': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'count': ('django.db.models.fields.FloatField', [], {}),
+            'geom': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'level_2_re': ('django.db.models.fields.FloatField', [], {}),
+            'region_nam': ('django.db.models.fields.CharField', [], {'max_length': '254'}),
+            'tdwg_code': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'dplace_app.glottocode': {
+            'Meta': {'object_name': 'GlottoCode'},
+            'glotto_code': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'dplace_app.isocode': {
+            'Meta': {'object_name': 'ISOCode'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.CharField', [], {'max_length': '3', 'db_index': 'True'}),
+            'location': ('django.contrib.gis.db.models.fields.PointField', [], {'null': 'True'})
+        },
+        u'dplace_app.language': {
+            'Meta': {'object_name': 'Language'},
+            'glotto_code': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.GlottoCode']", 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.ISOCode']", 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'})
+        },
+        u'dplace_app.languageclass': {
+            'Meta': {'ordering': "('level', 'name')", 'object_name': 'LanguageClass'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'level': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['dplace_app.LanguageClass']", 'null': 'True'})
+        },
+        u'dplace_app.languageclassification': {
+            'Meta': {'ordering': "('language__name',)", 'object_name': 'LanguageClassification', 'index_together': "[['class_family', 'class_subfamily', 'class_subsubfamily']]"},
+            'class_family': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'languages1'", 'null': 'True', 'to': u"orm['dplace_app.LanguageClass']"}),
+            'class_subfamily': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'languages2'", 'null': 'True', 'to': u"orm['dplace_app.LanguageClass']"}),
+            'class_subsubfamily': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'languages3'", 'null': 'True', 'to': u"orm['dplace_app.LanguageClass']"}),
+            'ethnologue_classification': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '250', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.Language']", 'null': 'True'}),
+            'scheme': ('django.db.models.fields.CharField', [], {'default': "'E'", 'max_length': '1'})
+        },
+        u'dplace_app.languagetree': {
+            'Meta': {'object_name': 'LanguageTree'},
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'languages': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['dplace_app.Language']", 'symmetrical': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'newick_string': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.Source']", 'null': 'True'})
+        },
+        u'dplace_app.society': {
+            'Meta': {'object_name': 'Society'},
+            'ext_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '10'}),
+            'focal_year': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'glotto_code': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'related_name': "'societies'", 'null': 'True', 'to': u"orm['dplace_app.GlottoCode']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'societies'", 'null': 'True', 'to': u"orm['dplace_app.ISOCode']"}),
+            'language': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'societies'", 'null': 'True', 'to': u"orm['dplace_app.Language']"}),
+            'location': ('django.contrib.gis.db.models.fields.PointField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'references': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.Source']", 'null': 'True'}),
+            'xd_id': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '10', 'null': 'True'})
+        },
+        u'dplace_app.source': {
+            'Meta': {'unique_together': "(('year', 'author'),)", 'object_name': 'Source'},
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'focal_year': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100'}),
+            'reference': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'subcase': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True'}),
+            'year': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'dplace_app.variablecategory': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'VariableCategory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30', 'db_index': 'True'})
+        },
+        u'dplace_app.variablecodedescription': {
+            'Meta': {'ordering': "('variable', 'code_number', 'code')", 'object_name': 'VariableCodeDescription'},
+            'code': ('django.db.models.fields.CharField', [], {'default': "'.'", 'max_length': '20', 'db_index': 'True'}),
+            'code_number': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'default': "'Unknown'", 'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'n': ('django.db.models.fields.IntegerField', [], {'default': '0', 'null': 'True'}),
+            'variable': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'codes'", 'to': u"orm['dplace_app.VariableDescription']"})
+        },
+        u'dplace_app.variablecodedvalue': {
+            'Meta': {'ordering': "('variable', 'coded_value')", 'unique_together': "(('variable', 'society', 'coded_value'),)", 'object_name': 'VariableCodedValue', 'index_together': "[['variable', 'society'], ['variable', 'coded_value'], ['variable', 'code'], ['society', 'coded_value'], ['society', 'code']]"},
+            'code': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.VariableCodeDescription']", 'null': 'True'}),
+            'coded_value': ('django.db.models.fields.CharField', [], {'default': "'.'", 'max_length': '100', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'society': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.Society']", 'null': 'True'}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.Source']", 'null': 'True'}),
+            'variable': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'values'", 'to': u"orm['dplace_app.VariableDescription']"})
+        },
+        u'dplace_app.variabledescription': {
+            'Meta': {'ordering': "('label',)", 'object_name': 'VariableDescription'},
+            'codebook_info': ('django.db.models.fields.TextField', [], {'default': "'None'"}),
+            'data_type': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index_categories': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'index_variables'", 'symmetrical': 'False', 'to': u"orm['dplace_app.VariableCategory']"}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "'Unknown'", 'max_length': '200', 'db_index': 'True'}),
+            'niche_categories': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'niche_variables'", 'symmetrical': 'False', 'to': u"orm['dplace_app.VariableCategory']"}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dplace_app.Source']", 'null': 'True'})
+        }
+    }
+
+    complete_apps = ['dplace_app']

--- a/dplace_app/models.py
+++ b/dplace_app/models.py
@@ -19,9 +19,7 @@ CLASS_LEVELS = (
 CLASSIFICATION_SCHEMES = (
     ('E', 'Ethnologue17',),
     ('R', 'Ethnologue17-Revised',),
-    ('G', 'Glottolog',), #CHECK THIS
-    #... any others as they become available. I can see a time in
-    # the not too distant future when we'll get better ones.
+    ('G', 'Glottolog',), 
 )
 
 
@@ -30,6 +28,7 @@ CLASSIFICATION_SCHEMES = (
 # Other datasets references ISO Codes that were not present in 16th ed, so now
 # this is loaded from the ethnologue, and locations are annotated later if known
 
+# We don't really need a location field here...
 class ISOCode(models.Model):
     iso_code = models.CharField('ISO Code', db_index=True, max_length=3)
     location = models.PointField(null=True) # only have locations for ISO codes in 16th ed ethnologue
@@ -60,7 +59,7 @@ class Society(models.Model):
     language = models.ForeignKey('Language', null=True, related_name="societies")
     objects = models.GeoManager()
     focal_year = models.CharField('Focal Year', null=True, blank=True, max_length=100)
-    references = models.TextField('References', null=True)
+    references = models.TextField('References', null=True) #why is this here???
 
     def get_environmental_data(self):
         """Returns environmental data for the given society"""
@@ -289,13 +288,17 @@ class VariableCodedValue(models.Model):
 
 class Source(models.Model):
     """
-    Stores references for VariableCodedValues
+    Stores references for VariableCodedValues, also for dataset sources.
+    Not really sure if we should separate dataset sources from references (I think we should),
+    but since all the code has already been written with this model, I won't change it yet.
     """
+    
     year = models.CharField(max_length=10) # text, because might be '1996', '1999-2001', or 'ND'
     author = models.CharField(max_length=50)
     reference = models.CharField(max_length=500)
     focal_year = models.CharField(max_length=10,null=True)
     subcase = models.CharField(max_length=32,null=True)
+    name = models.CharField(max_length=100, default="")
     
     def __unicode__(self):
         return "%s (%s)" % (self.author, self.year)

--- a/dplace_app/static/partials/search/cultural.html
+++ b/dplace_app/static/partials/search/cultural.html
@@ -23,7 +23,7 @@
                             ng-model="trait.selectedSource"
                             class="form-control"
                             ng-change="sourceChanged(trait)"
-                            ng-options='source as (source.author + " ("+source.year+")") for source in trait.sources'
+                            ng-options='source as (source.name) for source in trait.sources'
                             >
                             <option value="">Select a Source</option>
                         </select>

--- a/load_all_datasets.sh
+++ b/load_all_datasets.sh
@@ -43,23 +43,20 @@ export PYTHONPATH=$DPLACE_PATH
 #python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/Revised_Ethnologue_families-Feb_10_2014-17th_Ed-ISO693-3-current.csv" langs
 #python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/Revised_Ethnologue_families-Feb_10_2014-17th_Ed_Missing_ISO_codes.csv" langs
 
-#echo "Loading EA Societies"
-#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/ea_langs+isocodes.csv" ea_soc
+echo "Loading EA Societies"
+python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/ea_langs+isocodes.csv" ea_soc
 
 #echo "Loading EA Society and XD ID links"
 #python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_soc_id_to_xd_id_10Nov2015.csv" ea_soc_xd_id
 
-echo "Linking societies to locations"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_Binford_Lat_long.csv" soc_lat_long
+#echo "Linking societies to locations"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_Binford_Lat_long.csv" soc_lat_long
 
 #echo "Linking Societies to Glottocodes"
 #python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/xd_id_to_language_9Nov2015.csv" xd_lang
 
-#echo "Loading Binford Societies"
-#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/binford_langs+isocodes.csv" bf_soc
-
-#echo "Loading Binford Harmonized Societies"
-#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/binford_harm.csv" bf_harm
+echo "Loading Binford Societies"
+python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/binford_langs+isocodes.csv" bf_soc
 
 #echo "Loading Environmental Data"
 #python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EcologicalData.DBASE.07Mar14.csv" "env_vars"
@@ -75,9 +72,9 @@ python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_Binford_Lat_long
 
 #echo "Loading EA Variable Values"
 #python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/ea_vals.csv" ea_vals
+
 #echo "Loading EA Stacked Data"
 #python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_DATA_stacked_10Nov2015.csv" ea_stacked
-
 
 #echo "Loading Binford Variables"
 #python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/binford_variable_names+categories.csv" bf_vars


### PR DESCRIPTION
- Added 'name' field for Source model
- Updated sources.py get_source to store name of database (either Ethnographic Atlas or Binford Hunter-Gatherer)
- I commented out most of load_all_datasets.sh except for the code to store EA and Binford societies. To get the name of the source stored in the database, run the load_all_datasets.sh in this pull request (or run getting EA and Binford societies).