### PR TITLE
Fixing missing language error

### DIFF
--- a/dplace_app/load/glottocode.py
+++ b/dplace_app/load/glottocode.py
@@ -78,8 +78,7 @@ def xd_to_language(dict_row):
                     s.save()
             except ObjectDoesNotExist:
                 print "No language found for isocode %s and glottocode %s, skipping" % (isocode, glottocode)
-
-            return
+                return
             
     try:
         language = Language.objects.get(glotto_code=glotto, iso_code=iso)

--- a/load_all_datasets.sh
+++ b/load_all_datasets.sh
@@ -44,61 +44,61 @@ python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/glottolog_mapping_1
 echo "Mapping ISOCodes to Glottolog Codes"
 python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/glottolog_mapping.csv" glotto_iso
 
-echo "Loading EA Variables"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EAVariableList_17Nov2015.csv" vars
+#echo "Loading EA Variables"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EAVariableList_17Nov2015.csv" vars
 
-echo "Loading EA Variable Codes"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EACodeDescriptions_17Nov2015.csv" codes
+#echo "Loading EA Variable Codes"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EACodeDescriptions_17Nov2015.csv" codes
 
-echo "Loading Binford Variables" 
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/BinfordVariableList_18Nov2015.csv" vars
+#echo "Loading Binford Variables" 
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/BinfordVariableList_18Nov2015.csv" vars
 
-echo "Loading Binford Variable Codes" 
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/BinfordVariableListCodeDescription_18Nov2015.csv" codes
+#echo "Loading Binford Variable Codes" 
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/BinfordVariableListCodeDescription_18Nov2015.csv" codes
 
-echo "Loading EA Societies"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_Society_HeaderData.csv" ea_soc
+#echo "Loading EA Societies"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_Society_HeaderData.csv" ea_soc
 
-echo "Loading Binford Societies"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/Binford_Society_HeaderData.csv" bf_soc
+#echo "Loading Binford Societies"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/Binford_Society_HeaderData.csv" bf_soc
 
-echo "Linking Societies to Locations"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_Binford_Lat_Long.csv" soc_lat_long
+#echo "Linking Societies to Locations"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_Binford_Lat_Long.csv" soc_lat_long
 
 echo "Linking Societies to Glottocodes"
 python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/xd_id_to_language_11Dec2015.csv" xd_lang
 
-echo "Loading EA Data"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_DATA_Stacked_17Nov2015.csv" ea_vals
+#echo "Loading EA Data"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_DATA_Stacked_17Nov2015.csv" ea_vals
 
-echo "Loading References"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/ReferenceMapping_11Nov2015.csv" refs
+#echo "Loading References"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/ReferenceMapping_11Nov2015.csv" refs
 
-echo "Loading References for EA data"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_DATA_Stacked_17Nov2015.csv" ea_refs
+#echo "Loading References for EA data"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_DATA_Stacked_17Nov2015.csv" ea_refs
 
-echo "Loading Binford Data" 
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/Binford_merged_18Nov2015.csv" bf_vals
+#echo "Loading Binford Data" 
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/Binford_merged_18Nov2015.csv" bf_vals
 
 #echo "Loading References for Binford data" DO THIS!!
 #python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EA_DATA_Stacked_17Nov2015.csv" ea_refs
 
-echo "Loading Environmental Data"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EcologicalData.DBASE.07Mar14.csv" "env_vars"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EcologicalData.DBASE.07Mar14.csv" "env_vals"
+#echo "Loading Environmental Data"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EcologicalData.DBASE.07Mar14.csv" "env_vars"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/csv/EcologicalData.DBASE.07Mar14.csv" "env_vals"
 
-echo "Loading Geographic regions from shapefile"
-python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/geo/level2-shape/level2.shp" geo
+#echo "Loading Geographic regions from shapefile"
+#python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/geo/level2-shape/level2.shp" geo
 
-TREE_FILES="${REPO_DEST}/trees/*.trees"
-for tree_file in $TREE_FILES; do
-    echo "Loading Language tree $tree_file"   
-    if [[ $tree_file == *"glotto"* ]]
-    then
-        python "${DPLACE_PATH}/dplace_app/load.py" "$tree_file" glottotree
-    else
-        python "${DPLACE_PATH}/dplace_app/load.py" "$tree_file" tree
-    fi
-done
+#TREE_FILES="${REPO_DEST}/trees/*.trees"
+#for tree_file in $TREE_FILES; do
+#    echo "Loading Language tree $tree_file"   
+#    if [[ $tree_file == *"glotto"* ]]
+#    then
+#        python "${DPLACE_PATH}/dplace_app/load.py" "$tree_file" glottotree
+#    else
+#        python "${DPLACE_PATH}/dplace_app/load.py" "$tree_file" tree
+#    fi
+#done
 
 


### PR DESCRIPTION
An error in the Language Classification script meant that some languages were excluded from some language families (see #157 ). This has now been fixed.

Run load_all_datasets.sh (everything is commented out except the language code to run).