### PR TITLE
Rollback changes introduced due to incomplete settings

### DIFF
--- a/dplace_app/renderers.py
+++ b/dplace_app/renderers.py
@@ -65,9 +65,9 @@ class DPLACECSVResults(object):
             row['Society name'] = society['name']
             row['Society source'] = society['source']['name']
             row['Longitude'] = "" if society['location'] is None \
-                else society['location'][0]
+                else society['location']['coordinates'][0]
             row['Latitude'] = "" if society['location'] is None \
-                else society['location'][1]
+                else society['location']['coordinates'][1]
             if society['language'] is not None and 'name' in society['language']:
                 row['ISO code'] = society['language']['iso_code']
                 row['Language name'] = society['language']['name']

--- a/dplace_app/serializers.py
+++ b/dplace_app/serializers.py
@@ -1,5 +1,4 @@
 from rest_framework import serializers
-from django.core.serializers import serialize
 
 from dplace_app import models
 
@@ -120,7 +119,6 @@ class LanguageSerializer(serializers.ModelSerializer):
 class SocietySerializer(serializers.ModelSerializer):
     language = LanguageSerializer()
     source = SourceSerializer()
-    location = serializers.SerializerMethodField()
 
     class Meta(object):
         model = models.Society
@@ -133,9 +131,6 @@ class SocietySerializer(serializers.ModelSerializer):
             'language',
             'focal_year',
             'source')
-            
-    def get_location(self, obj):
-        return obj.location.coords
 
 
 class GeographicRegionSerializer(serializers.ModelSerializer):

--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -629,7 +629,7 @@ angular.module('dplaceMapDirective', [])
                     scope.results.societies.forEach(function(societyResult) {
                         var society = societyResult.society;
                         // Add a marker for each point
-                        var marker = {latLng: [society.location[1], society.location[0]], name: society.name}
+                        var marker = {latLng: [society.location.coordinates[1], society.location.coordinates[0]], name: society.name}
                         scope.map.addMarker(society.id, marker); 
                          if (!scope.chosen) {   
                             results = scope.results;

--- a/dplace_app/tests/test_api.py
+++ b/dplace_app/tests/test_api.py
@@ -496,6 +496,7 @@ class FindSocietiesTestCase(Test):
         self.assertFalse(self.society_in_results(self.society1, response))
         self.assertTrue(self.society_in_results(self.society2, response))
         self.assertFalse(self.society_in_results(self.society3, response))
+        self.assertIn('coordinates', response.data['societies'][0]['society']['location'])
 
     def test_find_by_geographic_region_mpoly(self):
         """


### PR DESCRIPTION
`rest_framework_gis` must now (0.10) be listed under the `INSTALLED_APPS`
setting, to make serialization of geo fields work as expected.