### PR TITLE
Changing language to language family

### DIFF
--- a/dplace_app/static/js/filters.js
+++ b/dplace_app/static/js/filters.js
@@ -91,8 +91,8 @@ angular.module('dplaceFilters', [])
     .filter('formatLanguage', function () {
         return function(values) {
             return values.map( function(language) {
-                return language.name;
-            }).join(',');
+                return language.family.name;
+            }).join('; ');
         };
     })
     .filter('formatLanguageTrees', function () {

--- a/dplace_app/static/partials/societies/table.html
+++ b/dplace_app/static/partials/societies/table.html
@@ -11,7 +11,7 @@
             <th>Trees</th>
             <th ng-repeat="variable in results.variable_descriptions">{{ variable.variable.name }}</th>
             <th ng-repeat="environmental in results.environmental_variables">{{ environmental.name }}</th>
-            <th ng-show="results.languages">Language</th>
+            <th ng-show="results.languages">Language Family</th>
             <th ng-show="results.geographic_regions">Geographic Region</th>
         </tr>
         <tr ng-repeat="society_result in results.societies | orderBy:columnSort.sortColumn:columnSort.reverse">


### PR DESCRIPTION
Fix for #181 . Instead of displaying two "Language" column, a language search will display a column with the language and a column with the language family.