### PR TITLE
Upgrade django-filter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==1.9.2
 django-appconf==1.0.1
 django-bootstrap3==6.2.2
-django-filter==0.11.0
+django-filter==0.12.0
 djangorestframework==3.3.2
 djangorestframework-csv==1.4.1
 djangorestframework-gis==0.10.1


### PR DESCRIPTION
To address #244 we need to upgrade the `django-filter` package. Note that this requires calling
```
pip install -r requirements.txt
```
upon deployment.