### PR TITLE
Fixing Binford duplicate value error, updating results table/CSV download for Binford data

### DIFF
--- a/dplace_app/renderers.py
+++ b/dplace_app/renderers.py
@@ -106,10 +106,30 @@ class DPLACECSVResults(object):
 
             # cultural
             cultural_trait_values = item['variable_coded_values']
+            extra_rows = [] # Binford societies may have multiple values for one variable
             for cultural_trait_value in cultural_trait_values:
                 # Figure out the column name
                 variable_id = cultural_trait_value['variable']
                 field_names = self.field_map['variable_descriptions'][variable_id]
+                if field_names['code'] in row:
+                    if 'code_description' in cultural_trait_value:
+                        try:
+                            description = cultural_trait_value['code_description']['description']
+                        except:
+                            description = ""
+                    else:
+                        description = ""
+                    extra_rows.append(dict({
+                        'Society name': society['name'],
+                        'Society source': society['source']['name'],
+                        field_names['code']: cultural_trait_value['coded_value'],
+                        field_names['description']: description,
+                        field_names['focal_year']: cultural_trait_value['focal_year'],
+                        field_names['comments']: cultural_trait_value['comment'],
+                        field_names['sources']: ''.join([x['author'] + '(' + x['year'] + '); ' for x in cultural_trait_value['references']])
+                    }))
+                    continue
+
                 row[field_names['code']] = cultural_trait_value['coded_value']
                 row[field_names['focal_year']] = cultural_trait_value['focal_year']
                 if 'code_description' in cultural_trait_value:
@@ -131,6 +151,8 @@ class DPLACECSVResults(object):
             # language - already have
             #
             self.rows.append(row)
+            for extra in extra_rows:
+                self.rows.append(extra)
 
 
 def encode_if_text(val):

--- a/dplace_app/renderers.py
+++ b/dplace_app/renderers.py
@@ -125,7 +125,7 @@ class DPLACECSVResults(object):
                         field_names['code']: cultural_trait_value['coded_value'],
                         field_names['description']: description,
                         field_names['focal_year']: cultural_trait_value['focal_year'],
-                        field_names['comments']: cultural_trait_value['comment'],
+                        field_names['comments']: cultural_trait_value['subcase'] + '; ' + cultural_trait_value['comment'],
                         field_names['sources']: ''.join([x['author'] + '(' + x['year'] + '); ' for x in cultural_trait_value['references']])
                     }))
                     continue
@@ -138,7 +138,7 @@ class DPLACECSVResults(object):
                             cultural_trait_value['code_description']['description']
                     except:
                         row[field_names['description']] = ''
-                row[field_names['comments']] = cultural_trait_value['comment']
+                row[field_names['comments']] = cultural_trait_value['subcase'] + '; '+ cultural_trait_value['comment']
                 row[field_names['sources']] = ''.join([
                     x['author'] + '(' + x['year'] + '); '
                     for x in cultural_trait_value['references']])

--- a/dplace_app/static/js/controllers/societies.js
+++ b/dplace_app/static/js/controllers/societies.js
@@ -353,29 +353,6 @@ function SocietiesCtrl($scope, $timeout, $http, searchModelService, colorMapServ
         });
     };
     
-    $scope.showComments = function(society, variable_id) {
-        for (var i = 0; i < society.variable_coded_values.length; i++) {
-            if (society.variable_coded_values[i].variable == variable_id) {
-                if ((society.variable_coded_values[i].focal_year.length > 0 && society.variable_coded_values[i].focal_year != 'NA') || society.variable_coded_values[i].comment.length > 0)
-                    return true
-                else    
-                    return false
-            }
-        }
-    };
-    
-    $scope.showSource = function(society, variable_id) {
-        for (var i = 0; i < society.variable_coded_values.length; i++) {
-            if (society.variable_coded_values[i].variable == variable_id) {
-                if (society.variable_coded_values[i].references.length > 0)
-                    return true;
-                else return false;
-            }
-        }
-        return false;
-    };
-
-    
     //NEW CSV DOWNLOAD CODE
     //Sends a POST (rather than GET) request to the server, then constructs a Blob and uses FileSaver.js to trigger the save as dialog
     //Better because we can send more data to the server using POST request than GET request

--- a/dplace_app/static/js/filters.js
+++ b/dplace_app/static/js/filters.js
@@ -50,13 +50,28 @@ angular.module('dplaceFilters', [])
             }
         }
     }])
+    .filter('numValues', function() {
+        return function(values, variable_id) {
+            return values.filter(function(code_value) {
+                if (code_value.code_description && (variable_id == code_value.code_description.variable)) return code_value;
+                else if (variable_id == code_value.variable) return code_value;
+            }).length - 1;
+        };
+    })
     .filter('formatVariableCodeValues', function() {
         return function(values, variable_id) {
-            return values.map( function(code_value) {   
-                if (code_value.code_description && (variable_id == code_value.code_description.variable)) return code_value.code_description.description;
-                else if (variable_id == code_value.variable) return code_value.coded_value;
-                else return ''
-            }).join('');
+            codes = values.filter( function(code_value) {   
+               if (code_value.code_description && (variable_id == code_value.code_description.variable)) return code_value;
+                else if (variable_id == code_value.variable) return code_value;
+            });
+            return [codes[0]];
+        };
+    })
+    .filter('formatValue', function() {
+        return function(value) {
+            if (!value) return '';
+            if (value.code_description) return value.code_description.description;
+            else return value.coded_value;
         };
     })
     .filter('formatEnvironmentalValues', function () {
@@ -68,38 +83,20 @@ angular.module('dplaceFilters', [])
         };
     })
     .filter('formatValueSources', function() {
-        return function(values, variable_id) {
-            return values.map( function(code_value) {
-                if (code_value.code_description && (variable_id == code_value.code_description.variable)) {
-                    return code_value.references.map(function(reference) {
-                        return reference.author + ' (' + reference.year + ')';
-                    });
-                }
-                else if (variable_id == code_value.variable) {
-                    return code_value.references.map(function(reference) {
-                        return reference.author + ' (' + reference.year + ')';
-                    });
-                }
-            }).join('')
+        return function(value) {
+            if (!value) return '';
+            return value.references.map(function(reference) {
+                return reference.author + ' (' + reference.year + ')';
+            }).join('; ');
         };
     })
     .filter('formatComment', function() {
-        return function(values, variable_id) {
+        return function(code_value) {
+            if (!code_value) return '';
             str = '';
-            return values.map( function(code_value) {
-                if (code_value.code_description && (variable_id == code_value.code_description.variable)) {
-                    if (code_value.focal_year != 'NA')
-                        str = 'Focal Year: ' + code_value.focal_year;
-                    if (code_value.comment) str += '\n' + code_value.comment;
-                    return str;
-                }
-                else if (variable_id == code_value.variable) {
-                    if (code_value.focal_year != 'NA') str = 'Focal Year: ' + code_value.focal_year;
-                    if (code_value.comment) str += '\n' + code_value.comment;
-                    return str;
-                } else return ''
-
-            }).join('')
+            if (code_value.focal_year != 'NA') str = 'Focal Year: ' + code_value.focal_year;
+            if (code_value.comment) str += '\n' + code_value.comment;
+            return str;
         };
     })
     .filter('formatLanguage', function () {

--- a/dplace_app/static/partials/societies/table.html
+++ b/dplace_app/static/partials/societies/table.html
@@ -23,13 +23,17 @@
             <td>{{ society_result.society.language | formatLanguageName }}</td>
             <td><a style="cursor: pointer;" ng-click="clicked(society_result.society.trees)" title="'Trees'">{{ society_result.society.trees | countOrBlank }}</a></td>
             <td ng-repeat="variable in results.variable_descriptions">
-                {{ society_result.variable_coded_values | formatVariableCodeValues:variable.variable.id }} <a ng-show="showSource(society_result, variable.variable.id)" data-toggle="collapse" data-target="#s{{society_result.society.ext_id}}{{variable.variable.label}}" class="source-link">(Source)</a>
-                <a ng-show="showComments(society_result, variable.variable.id)" class="comment-tooltip" tooltip="{{ society_result.variable_coded_values | formatComment:variable.variable.id }}">
-                    <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
-                </a>
+            <div ng-repeat="coded_value in society_result.variable_coded_values|formatVariableCodeValues:variable.variable.id">
+                {{ coded_value|formatValue }}
+                <a ng-show="coded_value.references.length > 0" data-toggle="collapse" data-target="#s{{society_result.society.ext_id}}{{variable.variable.label}}" class="source-link">(Source)</a>
+                <a ng-show="coded_value.comment.length > 0 || coded_value.subcase.length > 0 || (coded_value.focal_year.length > 0 && coded_value.focal_year != 'NA')" class="comment-tooltip" tooltip = "{{ coded_value|formatComment }}">
+                    <span class="glyphicon glyphicon-comment" aria-hidden="true"></span></a>
                 <div id="s{{society_result.society.ext_id}}{{variable.variable.label}}" class="collapse val-sources">
-                    {{ society_result.variable_coded_values | formatValueSources:variable.variable.id }}
+                    {{ coded_value | formatValueSources }}
                 </div>
+                <div ng-show="(society_result.variable_coded_values|numValues:variable.variable.id ) > 0" style="font-size:12px;"> {{ society_result.variable_coded_values|numValues:variable.variable.id }} more values for this society</div>
+
+            </div>
             </td>
             <td ng-repeat="environmental in results.environmental_variables">
                 {{ society_result.environmental_values | formatEnvironmentalValues:environmental.id }}

--- a/load_all_datasets.sh
+++ b/load_all_datasets.sh
@@ -68,7 +68,7 @@ python "${DPLACE_PATH}/dplace_app/load.py" \
 # Loading Data
 python "${DPLACE_PATH}/dplace_app/load.py" \
  "${REPO_DEST}/csv/EA_DATA_Stacked_1Mar2016.csv" \
- "${REPO_DEST}/csv/Binford_DATA_stacked_3Mar2016_utf8.csv" \
+ "${REPO_DEST}/csv/Binford_DATA_stacked_5Mar2016_utf8.csv" \
  vals
 
 # Loading Environmental Data


### PR DESCRIPTION
Kate sent me an updated Binford data file to address the warning about duplicate values for some societies. Run load_all_datasets.sh to fix this.

Related to PR which contains the new data file - https://github.com/SimonGreenhill/dplace-data/pull/6

Also fixed the society results table display for Binford variables with duplicate values, and updated CSV download code to include all duplicate values.