### PR TITLE
Fixing Society search 

### DIFF
--- a/dplace_app/api_views.py
+++ b/dplace_app/api_views.py
@@ -240,7 +240,8 @@ def result_set_from_query_dict(query_dict):
                     'source',
                     'language__family',
                     'language__iso_code'):
-            result_set.add_language(society, society.language)
+            if society.culturalvalue_set.count():
+                result_set.add_language(society, society.language)
 
     if 'c' in query_dict:
         criteria.append(serializers.SEARCH_VARIABLES)

--- a/dplace_app/load/environmental.py
+++ b/dplace_app/load/environmental.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 import logging
 
-from dplace_app.models import ISOCode, Society
+from dplace_app.models import ISOCode, Society, Language, LanguageFamily
 from dplace_app.models import Environmental, EnvironmentalCategory
 from dplace_app.models import EnvironmentalVariable, EnvironmentalValue
 from sources import get_source
@@ -61,6 +61,8 @@ def load_environmental(items):
         if _load_environmental(item, variables, societies, objs):
             res += 1
     EnvironmentalValue.objects.bulk_create(objs, batch_size=1000)
+    for language_family in LanguageFamily.objects.all():
+        language_family.update_counts()
     return res
 
 

--- a/dplace_app/load/glottocode.py
+++ b/dplace_app/load/glottocode.py
@@ -35,9 +35,6 @@ def xd_to_language(items, languoids):
 
         _xd_to_language(item, societies, ldata, languages, families, isocodes)
         count += 1
-
-    for language_family in LanguageFamily.objects.all():
-        language_family.update_counts()
     return count
 
 

--- a/dplace_app/models.py
+++ b/dplace_app/models.py
@@ -326,7 +326,10 @@ class LanguageFamily(models.Model):
     language_count = models.IntegerField(default=0, null=False)
 
     def update_counts(self):
-        self.language_count = Society.objects.all().filter(language__family=self).count()
+        self.language_count = 0
+        for society in Society.objects.all().filter(language__family=self):
+            if society.culturalvalue_set.count() > 0:
+                self.language_count += 1
         self.save()
 
 


### PR DESCRIPTION
Note that this requires reloading of data due to small change in language counts. We now store SCCS and WNAI societies (for the future), these are blank and shouldn't be counted in language counts or displayed in the society results table.

Fix for #276 .

