### PR TITLE
Removed db queries run when serializing.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,6 +14,7 @@ flake8 --exclude=migrations,static --ignore=E711,E712,D100,D101,D103,D102,D301,E
 ```
 coverage run --source='dplace_app' manage.py test
 coverage report -m
+npm test
 ```
 
 - Destroy database, upgrade and reload data:

--- a/dplace_app/models.py
+++ b/dplace_app/models.py
@@ -58,6 +58,10 @@ class Society(models.Model):
     chirila_link = models.CharField('CHIRILA', default = None, null=True, max_length=200)
 
     @property
+    def societies_count(self):
+        return len(self.societies)
+
+    @property
     def location(self):
         return dict(coordinates=[self.longitude, self.latitude])
         

--- a/dplace_app/serializers.py
+++ b/dplace_app/serializers.py
@@ -113,13 +113,9 @@ class LanguageFamilySerializer(serializers.ModelSerializer):
 
 
 class LanguageSerializer(serializers.ModelSerializer):
-    # glotto_code = serializers.CharField(source='glotto_code')
     iso_code = serializers.CharField(source='iso_code.iso_code')
     family = LanguageFamilySerializer()
-    count = serializers.SerializerMethodField()
-    
-    def get_count(self, language):
-        return models.Society.objects.all().filter(language=language).count()
+    count = serializers.ReadOnlyField(source='societies_count')
 
     class Meta(object):
         model = models.Language


### PR DESCRIPTION
With this PR we are down to the 17 db queries run for the search with place Siberia that we had before. Runtime of the `find_societies` request on my machine is down from 9.71 secs to 1.1.