### PR TITLE
Fixed loading of society location data

### DIFF
--- a/dplace_app/load.py
+++ b/dplace_app/load.py
@@ -44,7 +44,7 @@ def run(mode, *fnames):  # pragma: no cover
     if mode == 'xd_lang':
         return xd_to_language(csv_dict_reader(fnames[0]), csv_dict_reader(fnames[1]))
     if mode == 'soc_lat_long':
-        return society_locations(csv_dict_reader(fnames[0]), csv_dict_reader(fnames[1]))
+        return society_locations(csv_dict_reader(fnames[0]))
     if mode in ITEM_LOADER:
         return ITEM_LOADER[mode](chain(*map(csv_dict_reader, fnames)))
     raise ValueError(mode)

--- a/dplace_app/load/society.py
+++ b/dplace_app/load/society.py
@@ -8,13 +8,14 @@ from util import delete_all
 from sources import get_source
 
 
-def society_locations(region, items):
+def society_locations(items):
     societies = {s.ext_id: s for s in Society.objects.all()}
     regions = {r.region_nam: r for r in GeographicRegion.objects.all()}
     
-    society_region = {r['soc_id']: r['region'] for r in region}
     count = 0
     for item in items:
+        if item['dataset'] not in ['EA', 'Binford']:
+            continue
         society = societies.get(item['soc_id'])
         if not society:
             logging.warn("No matching society found for %s" % item)
@@ -31,9 +32,8 @@ def society_locations(region, items):
                 float, [item['origLat'], item['origLong']])
         except (TypeError, ValueError):
             logging.warn("Unable to create original coordinates for %s" % item)
-            
-            
-        region = regions.get(society_region.get(item['soc_id']))
+
+        region = regions.get(item['region'])
         if not region:
             logging.warn("No matching region found for %s" % item)
         else:
@@ -41,6 +41,7 @@ def society_locations(region, items):
         society.save()
         count += 1
     return count
+
 
 def load_societies(items):
     delete_all(Society)
@@ -100,5 +101,3 @@ def load_societies(items):
 
     Society.objects.bulk_create(societies)
     return len(societies)
-
-    

--- a/dplace_app/tests/data/LatLong_data.csv
+++ b/dplace_app/tests/data/LatLong_data.csv
@@ -1,6 +1,0 @@
-dataset,soc_id,origLat,origLong,Lat,Long,Comment
-Binford,soc1,3.00,114.00,3.00,114.00,Original
-Binford,soc2,8.58,81.25,8.59,81.19,Revised
-Binford,unknown,-15.32,124.72,-15.32,124.72,Original
-Binford,soc2,-16.91,127.83,-16.91,127.83,Original
-Binford,soc2,-16.30,139.30,-16.48,139.32,Revised

--- a/dplace_app/tests/data/society_locations.csv
+++ b/dplace_app/tests/data/society_locations.csv
@@ -1,6 +1,6 @@
-soc_id,Latitude,Longitude,OldLat,OldLong,region,tdwg_code
-soc1,-14,130,-14,130,Northern Europe,10
-soc2,-5,150,-5,150,Middle Europe,11
-soc-unknown,-5,150,-5,150,Middle Europe,11
-soc2,xx,xx,-5,150,Middle Europe,11
-soc2,-5,150,-5,150,Unknown Region,xx
+dataset,soc_id,origLat,origLong,Lat,Long,Comment,region
+Binford,soc1,3.00,114.00,3.00,114.00,Original,Northern Europe
+Binford,soc2,8.58,81.25,8.59,81.19,Revised,Middle Europe
+Binford,unknown,-15.32,124.72,-15.32,124.72,Original,Middle Europe
+Binford,soc2,-16.91,127.83,-16.91,127.83,Original,Middle Europe
+Binford,soc2,-16.30,139.30,-16.48,139.32,Revised,Unknown Region

--- a/dplace_app/tests/test_load.py
+++ b/dplace_app/tests/test_load.py
@@ -52,7 +52,7 @@ class LoadTestCase(TestCase):
     def test_load_society_locations(self):
         load_regions(data_path('test_geo.json'))
         load_societies(csv_dict_reader(data_path('societies.csv')))
-        society_locations(csv_dict_reader(data_path('society_locations.csv')), csv_dict_reader(data_path('LatLong_data.csv')))
+        society_locations(csv_dict_reader(data_path('society_locations.csv')))
 
     def test_load_trees(self):
         iso = ISOCode.objects.create(iso_code='abc')

--- a/load_all_datasets.sh
+++ b/load_all_datasets.sh
@@ -41,7 +41,6 @@ python "${DPLACE_PATH}/dplace_app/load.py" "${REPO_DEST}/geo/level2.json" geo
 # Linking Societies to Locations
 python "${DPLACE_PATH}/dplace_app/load.py" \
   "${REPO_DEST}/csv/society_locations.csv" \
-  "${REPO_DEST}/csv/LatLong_data.csv" \
   soc_lat_long
 
 # Loading Variables


### PR DESCRIPTION
Location data for society, including the mapping to regions, should only
use the data file `csv/society_locations.csv`, which is created using the
procdure described at
https://github.com/SimonGreenhill/dplace-data/blob/master/scripts/README.md

Note: This change depends on the updates for the data repos implemented in
https://github.com/SimonGreenhill/dplace-data/pull/11

Closes #293 