### PR TITLE
removed unnecessary db queries

### DIFF
--- a/dplace_app/api_views.py
+++ b/dplace_app/api_views.py
@@ -161,7 +161,7 @@ class LargeResultsSetPagination(PageNumberPagination):
 
 
 class LanguageViewSet(viewsets.ReadOnlyModelViewSet):
-    serializer_class = serializers.LanguageSerializer
+    serializer_class = serializers.LanguageSerializerWithSocieties
     filter_fields = ('name', 'iso_code', 'societies', 'family',)
     queryset = models.Language.objects.all()\
         .select_related('family', 'iso_code')\
@@ -224,8 +224,6 @@ def trees_from_languages_array(language_ids):
             'taxa__languagetreelabelssequence_set__society__language__family',
             'taxa__languagetreelabelssequence_set__society__language__iso_code',
         ).distinct()
-        #.prefetch_related('languages__family', 'languages__iso_code')\
-        #.distinct()
     for t in trees:
         #get the labels associated with this tree
         #determine which to keep and which to prune
@@ -350,10 +348,6 @@ def result_set_from_query_dict(query_dict):
     result_set.finalize(criteria)
 
     # search for language trees
-    #language_ids = []
-    #for s in result_set.societies:
-    #    if s.society.language:
-    #        language_ids.append(s.society.language.id)
     ext_ids = []
     for s in result_set.societies:
         ext_ids.append(s.society.ext_id)

--- a/dplace_app/serializers.py
+++ b/dplace_app/serializers.py
@@ -124,6 +124,21 @@ class LanguageSerializer(serializers.ModelSerializer):
             'glotto_code',
             'iso_code',
             'family',
+        )
+
+
+class LanguageSerializerWithSocieties(serializers.ModelSerializer):
+    iso_code = serializers.CharField(source='iso_code.iso_code')
+    family = LanguageFamilySerializer()
+
+    class Meta(object):
+        model = models.Language
+        fields = (
+            'id',
+            'name',
+            'glotto_code',
+            'iso_code',
+            'family',
             'societies',
         )
 


### PR DESCRIPTION
Reusing serializers across different kinds of views is sub-optimal, because this may result in either excessive amounts of db queries, or bloated single db queries in many places, just because the serializer defaults to serializing all attributes, rather than only the necessary ones. I recommend we adopt a policy to
- either use custom, optimized serializers for the critical code paths (search, mainly, I think)
- or have the default serializers as lean as possible, using custom serializers when more attributes are needed.