### PR TITLE
Optimized society serializer for language trees

### DIFF
--- a/dplace_app/api_views.py
+++ b/dplace_app/api_views.py
@@ -315,9 +315,7 @@ def result_set_from_query_dict(query_dict):
             .filter(taxa__societies__id__in=soc_ids)\
             .prefetch_related(
                 'taxa__languagetreelabelssequence_set__labels',
-                'taxa__languagetreelabelssequence_set__society__source',
-                'taxa__languagetreelabelssequence_set__society__language__family',
-                'taxa__languagetreelabelssequence_set__society__language__iso_code',
+                'taxa__languagetreelabelssequence_set__society',
             )\
             .distinct():
         update_newick(t, labels)

--- a/dplace_app/serializers.py
+++ b/dplace_app/serializers.py
@@ -163,20 +163,28 @@ class SocietySerializer(serializers.ModelSerializer):
         )
 
 
+class TreeSocietySerializer(serializers.ModelSerializer):
+    class Meta(object):
+        model = models.Society
+        fields = ('id', 'ext_id', 'name')
+
+
 class GeographicRegionSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = models.GeographicRegion
         fields = (
             'id', 'level_2_re', 'count', 'region_nam', 'continent', 'tdwg_code'
         )
-        
+
+
 class LanguageTreeLabelsSequenceSerializer(serializers.HyperlinkedModelSerializer):
-    society = SocietySerializer()
+    society = TreeSocietySerializer()
     labels = serializers.ReadOnlyField(source='labels.label')
     
     class Meta:
         model = models.LanguageTreeLabelsSequence
         fields = ('society', 'labels', 'fixed_order')
+
 
 class LanguageTreeLabelsSerializer(serializers.ModelSerializer):
     societies = LanguageTreeLabelsSequenceSerializer(source='languagetreelabelssequence_set', many=True)


### PR DESCRIPTION
This PR exemplifies how serializers could be optimized for better
performance. The data about the language and source a society is related
to is already present in the `societies` member of a search results object,
thus it doesn't have to be serialized again for the society objects related
to taxa in a `LanguageTree`. This optimization alone cuts the time for a
"tree-intensive" search like "culture->EA->Class->EA066" on my machine from
about 10 secs to 5.5 secs.