### PR TITLE
Make datasets to be loaded configurable

### DIFF
--- a/dplace/settings.template
+++ b/dplace/settings.template
@@ -1,4 +1,5 @@
 # Django settings for dplace project.
+DATASETS = ['EA', 'Binford']
 
 DEBUG = False
 

--- a/dplace/settings.travis
+++ b/dplace/settings.travis
@@ -1,4 +1,5 @@
 # Django settings for dplace project.
+DATASETS = ['EA', 'Binford']
 
 DEBUG = True
 

--- a/dplace_app/load.py
+++ b/dplace_app/load.py
@@ -10,6 +10,7 @@ import django
 django.setup()
 
 from django.db import transaction
+from django.conf import settings
 
 from load.util import configure_logging, csv_dict_reader
 from load.society import society_locations, load_societies
@@ -32,39 +33,29 @@ def csv_items(*names):
     return chain(*[csv_dict_reader(csv_path(name)) for name in names])
 
 
+def csv_names(pattern):
+    return [pattern % dataset for dataset in settings.DATASETS]
+
+
 def main():  # pragma: no cover
     configure_logging()
 
     for spec in [
-        # Loading Societies
-        (
-            load_societies,
-            csv_items(
-                'EA_header_data_24Feb2016.csv', 'Binford_header_data_24Feb2016.csv')),
-        # Loading Geographic regions
+        (load_societies, csv_items(*csv_names('%s_societies.csv'))),
         (load_regions, data_path('geo', 'level2.json')),
-        # Linking Societies to Locations
         (society_locations, csv_items('society_locations.csv')),
-        # Loading Variables
-        (load_vars, csv_items('EAVariableList.csv', 'BinfordVariableList.csv')),
-        # Loading Variable Codes
-        (
-            load_codes,
-            csv_items('EACodeDescriptions.csv', 'BinfordCodeDescriptions.csv')),
+        (load_vars, csv_items(*csv_names('%sVariableList.csv'))),
+        (load_codes, csv_items(*csv_names('%sCodeDescriptions.csv'))),
         # Linking Societies to Languoids
         (
             xd_to_language,
             csv_items('xd_id_to_language.csv'), csv_items('glottolog.csv')),
-        # Loading References
         (
             load_references,
             csv_items('ReferenceMapping.csv', 'BinfordReferenceMapping.csv')),
-        # Loading Data
-        (load_data, csv_items('EA_DATA_Stacked.csv', 'Binford_DATA_stacked.csv')),
-        # Loading Environmental Data
-        (load_environmental_var, csv_items('EnvironmentalVariables.csv')),
-        (load_environmental, csv_items('EnvData.csv')),
-        # Loading Trees
+        (load_data, csv_items(*csv_names('%s_data.csv'))),
+        (load_environmental_var, csv_items('environmentalVariableList.csv')),
+        (load_environmental, csv_items('environmental_data.csv')),
         (load_trees, data_path('trees')),
         (tree_names, data_path('csv')),
         (prune_trees,),

--- a/dplace_app/load/environmental.py
+++ b/dplace_app/load/environmental.py
@@ -2,7 +2,9 @@
 from __future__ import unicode_literals
 import logging
 
-from dplace_app.models import ISOCode, Society, Language, LanguageFamily
+from django.conf import settings
+
+from dplace_app.models import ISOCode, Society, LanguageFamily
 from dplace_app.models import Environmental, EnvironmentalCategory
 from dplace_app.models import EnvironmentalVariable, EnvironmentalValue
 from sources import get_source
@@ -59,7 +61,7 @@ def load_environmental(items):
     res = 0
     objs = []
     for item in items:
-        if item['Dataset'] in ['EA', 'Binford']:
+        if item['Dataset'] in settings.DATASETS:
             if _load_environmental(item, variables, societies, objs):
                 res += 1
     EnvironmentalValue.objects.bulk_create(objs, batch_size=1000)
@@ -102,18 +104,18 @@ def _load_environmental(val_row, variables, societies, objs):
         )
     else:
         environmental = found_environmentals[0]
-        
-    variable = variables.get(val_row['variable'])
+
+    variable = variables.get(val_row['VarID'])
     if variable is None:
-        if val_row['variable'] not in _missing_variables:
-            logging.warn("Could not find environmental variable %s" % val_row['variable'])
-            _missing_variables.add(val_row['variable'])
+        if val_row['VarID'] not in _missing_variables:
+            logging.warn("Could not find environmental variable %s" % val_row['VarID'])
+            _missing_variables.add(val_row['VarID'])
         return
 
     objs.append(EnvironmentalValue(
         variable=variable,
-        value=float(val_row['value']),
-        comment=val_row['comment'],
+        value=float(val_row['Code']),
+        comment=val_row['Comment'],
         environmental=environmental,
         source=source
     ))

--- a/dplace_app/load/society.py
+++ b/dplace_app/load/society.py
@@ -2,6 +2,8 @@
 from __future__ import unicode_literals
 import logging
 
+from django.conf import settings
+
 from dplace_app.models import Society, GeographicRegion
 
 from util import delete_all
@@ -14,7 +16,7 @@ def society_locations(items):
     
     count = 0
     for item in items:
-        if item['dataset'] not in ['EA', 'Binford']:
+        if item['dataset'] not in settings.DATASETS:
             continue
         society = societies.get(item['soc_id'])
         if not society:
@@ -44,59 +46,44 @@ def society_locations(items):
 
 
 def load_societies(items):
+    society_links = [
+        'SCCS_society_equivalent',
+        'WNAI_society_equivalent1',
+        'WNAI_society_equivalent2',
+        'WNAI_society_equivalent3',
+        'WNAI_society_equivalent4',
+        'WNAI_society_equivalent5',
+    ]
     delete_all(Society)
     societies = []
     for item in items:
-        if item['dataset'] == 'EA':
-            source = get_source("EA")
-        elif item['dataset'] == 'Binford':
-            source = get_source("Binford")    
-        else:
-            logging.warn(
-                "Could not determine source for row %s, skipping" % item
-            )
-            continue
-        
         societies.append(Society(
             ext_id=item['soc_id'],
             xd_id=item['xd_id'],
             original_name=item['ORIG_name_and_ID_in_this_dataset'],
             name=item['pref_name_for_society'], 
-            source=source,
+            source=get_source(item['dataset']),
             alternate_names=item['alt_names_by_society'],
             focal_year=item['main_focal_year'],
             hraf_link=item['HRAF_name_ID'],
             chirila_link=item['CHIRILA_society_equivalent']
         ))
-        
-        society_links = [
-            'SCCS_society_equivalent', 
-            'WNAI_society_equivalent1',
-            'WNAI_society_equivalent2',
-            'WNAI_society_equivalent3',
-            'WNAI_society_equivalent4',
-            'WNAI_society_equivalent5',
-        ]
-        
-        for key in item:
-            if key not in society_links:
-                continue
-            if item[key]:
-                source = get_source(key[0:key.find('_')])
-                ext_id = item[key].split('(')[len(item[key].split('('))-1]
+        for key in society_links:
+            value = item.get(key)
+            if value:
+                ext_id = value.split('(')[len(value.split('(')) - 1]
                 society = Society(
-                    ext_id=ext_id[0:len(ext_id)-1], 
+                    ext_id=ext_id[0:len(ext_id) - 1],
                     xd_id=item['xd_id'],
-                    original_name=item[key],
+                    original_name=value,
                     name=item['pref_name_for_society'],
                     alternate_names=item['alt_names_by_society'],
                     focal_year=item['main_focal_year'],
-                    source=source
+                    source=get_source(key[0:key.find('_')])
                 )
                 if society.ext_id not in [x.ext_id for x in societies]:
-                    societies.append(society)
                     logging.info("Saving society %s" % society.ext_id)
-                
+
         logging.info("Saving society %s" % item)
 
     Society.objects.bulk_create(societies)

--- a/dplace_app/load/sources.py
+++ b/dplace_app/load/sources.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import logging
+
 from dplace_app.models import Source
+from django.conf import settings
 
 _SOURCE_CACHE = {}
 SOURCE_DATA = {
@@ -21,8 +23,9 @@ SOURCE_DATA = {
                   "Environmental Data Sets. University of California Press",
         name="Binford Hunter-Gatherer",
     ),
-    
-    # data from these databases are not stored in our database, but the easiest way to link our societies to external databases is to do this, rather than create new fields for the Society model
+    # data from these databases are not stored in our database, but the easiest way to
+    # link our societies to external databases is to do this, rather than create new
+    # fields for the Society model
     'SCCS': dict(
         year="1969",
         author="Murdock",
@@ -39,6 +42,7 @@ SOURCE_DATA = {
         reference=""
     )
 }
+assert all(dataset in SOURCE_DATA for dataset in settings.DATASETS)
 
 
 def get_source(source='EA'):

--- a/dplace_app/load/util.py
+++ b/dplace_app/load/util.py
@@ -7,6 +7,9 @@ from six import BytesIO
 from django.db import connection
 
 
+DATASET_SHORT = {'Binford': 'B'}
+
+
 def delete_all(model):
     model.objects.all().delete()
     with connection.cursor() as c:
@@ -15,12 +18,8 @@ def delete_all(model):
         )
 
 
-def eavar_number_to_label(number):
-    return "EA{0:0>3}".format(number)
-
-
-def bfvar_number_to_label(number):
-    return "B{0:0>3}".format(number)
+def var_number_to_label(dataset, number):
+    return "{0}{1:0>3}".format(DATASET_SHORT.get(dataset, dataset), number)
 
 
 def configure_logging(test=False):

--- a/dplace_app/load/variables.py
+++ b/dplace_app/load/variables.py
@@ -3,7 +3,7 @@ import logging
 from dplace_app.models import CulturalVariable, CulturalCategory, CulturalCodeDescription
 
 from sources import get_source
-from util import eavar_number_to_label, bfvar_number_to_label
+from util import var_number_to_label
 
 
 def clean_category(category):
@@ -12,7 +12,6 @@ def clean_category(category):
 
 def load_vars(items):
     categories = {}
-
     count = 0
     for item in items:
         if load_var(item, categories):
@@ -21,27 +20,14 @@ def load_vars(items):
 
 
 def load_var(var_dict, categories):
-    """
-    Load variables from VariableList.csv
-    """
-    if var_dict['Dataset'] == 'EA':
-        label = eavar_number_to_label(var_dict['VarID'])
-        source = get_source("EA")
-    elif var_dict['Dataset'] == 'Binford':
-        label = bfvar_number_to_label(var_dict['VarID'])
-        source = get_source("Binford")
-    else:
-        logging.warn("Dataset %(Dataset)s not in database, skipping row" % var_dict)
-        return False
-
+    label = var_number_to_label(var_dict['Dataset'], var_dict['VarID'])
     variable, created = CulturalVariable.objects.get_or_create(
-        label=label, source=source)
+        label=label, source=get_source(var_dict['Dataset']))
     variable.name = var_dict['VarTitle']
     variable.codebook_info = var_dict['VarDefinition']
     variable.data_type = var_dict['VarType']
     assert variable.data_type in ['Continuous', 'Categorical', 'Ordinal']
-    variable.units = "" if 'Units' not in var_dict \
-        else var_dict['Units']
+    variable.units = "" if 'Units' not in var_dict else var_dict['Units']
 
     for c in map(clean_category, var_dict['IndexCategory'].split(',')):
         index_category = categories.get(c)
@@ -61,26 +47,13 @@ def load_var(var_dict, categories):
 def load_codes(items):
     count = 0
     for row in items:
-        dataset = row['Dataset']
-        code = row['Code']
-        id = row['VarID']
-        description = row['CodeDescription']
-        short_description = row['ShortName']
-        
-        if dataset == 'EA':
-            label = eavar_number_to_label(id)
-        elif dataset == 'Binford':
-            label = bfvar_number_to_label(id)
-        else:
-            logging.warn("Unknown dataset, skipping row %s" % row)
-            continue
-
+        label = var_number_to_label(row['Dataset'], row['VarID'])
         variable = CulturalVariable.objects.filter(label=label).first()
         if variable:
             code_description, created = CulturalCodeDescription.objects.get_or_create(
-                variable=variable, code=code)
-            code_description.description = description
-            code_description.short_description = short_description
+                variable=variable, code=row['Code'])
+            code_description.description = row['CodeDescription']
+            code_description.short_description = row['ShortName']
             code_description.save()
             logging.info(
                 ("Created CulturalCodeDescription: %s" % code_description).decode('utf8'))

--- a/dplace_app/tests/data/variables.csv
+++ b/dplace_app/tests/data/variables.csv
@@ -1,4 +1,3 @@
 Dataset,IndexCategory,VarID,VarTitle,VarDefinition,VarType,MainCategory,Source,Changes,UserNotes,Units
 EA,Subsistence,1,The Title,"The definition.",Ordinal,Category,Source1 (2000); Source2 (1999),,,%
 Binford,Subsistence,1,The Title,"The definition.",Ordinal,Category,Source1 (2000); Source2 (1999),,,
-UNKNOWN,Subsistence,1,The Title,"The definition.",Ordinal,Category,Source1 (2000); Source2 (1999),,,

--- a/dplace_app/tests/test_load.py
+++ b/dplace_app/tests/test_load.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from dplace_app.models import (
     Society, GeographicRegion, Language, LanguageTree, LanguageTreeLabels, LanguageTreeLabelsSequence, ISOCode, CulturalVariable,
 )
-from dplace_app.load.util import csv_dict_reader, eavar_number_to_label, configure_logging
+from dplace_app.load.util import csv_dict_reader, var_number_to_label, configure_logging
 from dplace_app.load.isocode import load_isocode
 from dplace_app.load.society import load_societies, society_locations
 from dplace_app.load.values import load_data
@@ -45,7 +45,7 @@ class LoadTestCase(TestCase):
         self.assertEqual(res, 2)
 
     def test_load_codes(self):
-        CulturalVariable.objects.create(label=eavar_number_to_label(1))
+        CulturalVariable.objects.create(label=var_number_to_label('EA', 1))
         load_codes(csv_dict_reader(data_path('code_descriptions.csv')))
         # FIXME: assertions!
 
@@ -126,7 +126,8 @@ class LoadTestCase(TestCase):
                 hraf_link='Example (EX1)',
                 chirila_link='Example (1)',
                 main_focal_year='2016')
-        self.assertEqual(load_societies([society('EA'), society('Binford'), society('x')]), 2)
+        self.assertEqual(load_societies([society('EA'), society('Binford')]), 2)
+        self.assertRaises(ValueError, load_societies, [society('x')])
 
     def test_load_data(self):
         self.assertEqual(load_data([self.get_dict()]), 0)
@@ -160,9 +161,9 @@ class LoadTestCase(TestCase):
         res = load_environmental([self.get_dict(**{
             'Dataset': 'EA',
             'soc_id': 'EA12',
-            'variable': 'AnnualMeanTemperature',
-            'value': 1,
-            'comment': "Comment"
+            'VarID': 'AnnualMeanTemperature',
+            'Code': 1,
+            'Comment': "Comment"
         })])
         self.assertEqual(res, 1)
     


### PR DESCRIPTION
In addition to adapting the load process to the new file names introduced in
the data repository, the list of datasets to be loaded is now a setting in
`dplace/settings.py`, which can be accessed as `django.conf.settings.DATASETS`.

This makes for less code in the load scripts as well as for easier addition of
more datasets.

Note that deploying this change requires
- updating the local `dplace/settings.py`
- updating the data repos clone (after https://github.com/SimonGreenhill/dplace-data/pull/19 has been merged)
- re-loading the data