### PR TITLE
Adding NEXUS download for trees

### DIFF
--- a/dplace_app/static/js/controllers/societies.js
+++ b/dplace_app/static/js/controllers/societies.js
@@ -322,6 +322,8 @@ function SocietiesCtrl($scope, $timeout, $http, searchModelService, colorMapServ
         legends_list = [];
         var gradients_svg = d3.select("#gradients-div").node().innerHTML;
         
+        
+        
         d3.selectAll(".legends").each( function(){
             leg = d3.select(this);
             if (leg.attr("var-id")) {
@@ -335,12 +337,20 @@ function SocietiesCtrl($scope, $timeout, $http, searchModelService, colorMapServ
             legend_id = all_legends[id];
             name = $scope.results.variable_descriptions[i].CID + '-'+ $scope.results.variable_descriptions[i].variable.name;
             svg_string = legend_id.node().innerHTML;
+            while (svg_string.indexOf("url(societies") != -1) { //strip out the societies part of the URL because this won't work in our download
+                index = svg_string.indexOf("url(societies");
+                svg_string = svg_string.substring(0, index+4) + svg_string.substring(index+13)
+            }
             svg_string = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" transform="translate(10, 10)">' + svg_string + gradients_svg + '</svg>';
             legends_list.push({'name': name.replace(/[\W]+/g, "-")+'-legend.svg', 'svg': svg_string});    
         }
         
         for (var i = 0; i < $scope.results.environmental_variables.length; i++) {
             env_svg = d3.select("#e"+$scope.results.environmental_variables[i].id).select("div").node().innerHTML;
+            while (env_svg.indexOf("url(societies") != -1) {
+                index = env_svg.indexOf("url(societies");
+                env_svg = env_svg.substring(0, index+4) + env_svg.substring(index+13)
+            }
             env_svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" transform="translate(10, 10)">'+env_svg.substring(0, env_svg.indexOf("</svg>")) + '</svg>' + gradients_svg + '</svg>';
             name = $scope.results.environmental_variables[i].CID + '-'+$scope.results.environmental_variables[i].name;
             legends_list.push({'name': name.replace(/[\W]+/g, "-")+'-legend.svg', 'svg': env_svg});

--- a/dplace_app/static/js/controllers/societies.js
+++ b/dplace_app/static/js/controllers/societies.js
@@ -305,6 +305,14 @@ function SocietiesCtrl($scope, $timeout, $http, searchModelService, colorMapServ
         $scope.tabs[2].active = true;
     }
     
+    $scope.nexusDownload = function() {
+        console.log($scope.results.selectedTree);
+        var filename = $scope.results.selectedTree.name+"-d-place.NEXUS";
+        string = "#NEXUS\nBEGIN TREES;\nTREE " + $scope.results.selectedTree.name+" = " + $scope.results.selectedTree.newick_string+"\nEND;"
+        file = new Blob([string], {type: 'text/nexus'});
+        saveAs(file, filename);
+    }
+    
     $scope.treeDownload = function() {
         var tree_svg = d3.select(".phylogeny")
             .attr("version", 1.1)

--- a/dplace_app/static/partials/societies/tree.html
+++ b/dplace_app/static/partials/societies/tree.html
@@ -23,8 +23,15 @@
         >
         <option value="">Select a Tree</option>
     </select>
-    <div class="tree-download">
-       <button ng-show="!globalTree && results.selectedTree" ng-click="treeDownload()" class="btn btn-info btn-dplace-download">Download This Phylogeny</button>
+        <div ng-show="!globalTree && results.selectedTree" class="btn-group" style="margin-top:10px;">
+          <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Download This Phylogeny
+            <span class="caret" style="margin-left:5px;"></span>
+            </button>
+          <ul class="dropdown-menu">
+            <li><a ng-click="treeDownload()">As SVG image</a></li>
+            <li><a ng-click="nexusDownload()">As NEXUS file</a></li>
+          </ul>
     </div>
     <table>
     <tr>


### PR DESCRIPTION
Currently, NEXUS file is in same format as original file. We should change the tree load script so that the newick string saved in the database has our society labels instead of the ones from the original files, since we use society labels anyway. Once that change has been made, the NEXUS file downloaded will have our society names as labels. (Fix for #156  )