### PR TITLE
refactored society search

### DIFF
--- a/dplace_app/api_views.py
+++ b/dplace_app/api_views.py
@@ -4,6 +4,7 @@ import datetime
 from itertools import groupby
 import logging
 
+from django.db import connection
 from django.db.models import Prefetch, Q
 from django.shortcuts import get_object_or_404
 from django.http import Http404, HttpResponseRedirect
@@ -195,25 +196,18 @@ def result_set_from_query_dict(query_dict):
     log.info('enter result_set_from_query_dict')
 
     result_set = serializers.SocietyResultSet()
-    # Criteria keeps track of what types of data were searched on, so that we can
-    # AND them together
-    criteria = []
+    sql_joins, sql_where = [], []
+
+    def id_array(l):
+        return '(%s)' % ','.join('%s' % int(i) for i in l)
 
     if 'l' in query_dict:
-        criteria.append(serializers.SEARCH_LANGUAGE)
-        for society in models.Society.objects\
-                .filter(language_id__in=query_dict['l'])\
-                .select_related(
-                    'source',
-                    'language__family',
-                    'language__iso_code')\
-                .prefetch_related('culturalvalue_set'):
-            if society.culturalvalue_set.count():
-                result_set.add_language(society, society.language)
+        sql_joins.append(('language', 'l', 'l.id = s.language_id'))
+        sql_where.append('l.id IN ' + id_array(query_dict['l']))
+        for lang in models.Language.objects.filter(id__in=query_dict['l']):
+            result_set.languages.add(lang)
 
     if 'c' in query_dict:
-        criteria.append(serializers.SEARCH_VARIABLES)
-
         variables = {
             v.id: v for v in models.CulturalVariable.objects
             .filter(id__in=[x['variable'] for x in query_dict['c']])
@@ -229,76 +223,104 @@ def result_set_from_query_dict(query_dict):
         ):
             variable = variables[variable]
             codes = list(codes)
+            alias = 'cv%s' % variable.id
+            sql_joins.append((
+                "culturalvalue",
+                alias,
+                "{0}.society_id = s.id AND {0}.variable_id = {1}".format(alias, variable.id)
+            ))
 
             if variable.data_type and variable.data_type == 'Continuous':
                 include_NA = not all('min' in c for c in codes)
-                query = reduce(
-                    lambda q, x: q | Q(
-                        coded_value_float__gt=x['min'], coded_value_float__lt=x['max']),
-                    [c for c in codes if 'min' in c],
-                    Q(id=0))
+                ors = [
+                    "({0}.coded_value_float >= %(min)f AND {0}.coded_value_float <= %(max)f)".format(alias) % c
+                    for c in codes if 'min' in c]
                 if include_NA:
-                    query = query | Q(coded_value='NA')
-
-                values = models.CulturalValue.objects\
-                    .filter(variable=variable)\
-                    .filter(query)
+                    ors.append("%s.coded_value = 'NA'" % alias)
+                sql_where.append("(%s)" % ' OR '.join(ors))
                 if not include_NA:
-                    values = values.exclude(coded_value='NA')
+                    sql_where.append("{0}.coded_value != 'NA'".format(alias))
             else:
                 assert all('id' in c for c in codes)
-                values = models.CulturalValue.objects \
-                    .filter(code_id__in=[x['id'] for x in codes])
+                sql_where.append("{0}.code_id IN %s".format(alias) % id_array([x['id'] for x in codes]))
 
-            for value in values\
-                    .select_related('code')\
-                    .select_related('society__language__family')\
-                    .select_related('society__language__iso_code')\
-                    .select_related('society__source')\
-                    .prefetch_related('references'):
-                result_set.add_cultural(value.society, variable, variable.codes, value)
+            result_set.variable_descriptions.add(serializers.VariableCode(variable.codes, variable))
 
     if 'e' in query_dict:
-        criteria.append(serializers.SEARCH_ENVIRONMENTAL)
         # There can be multiple filters, so we must aggregate the results.
-        for varid, operator, params in query_dict['e']:
-            values = models.EnvironmentalValue.objects.filter(variable_id=varid)
-            if operator == 'inrange':
-                values = values.filter(value__gt=params[0]).filter(value__lt=params[1])
-            elif operator == 'outrange':
-                values = values.filter(value__gt=params[1]).filter(value__lt=params[0])
-            elif operator == 'gt':
-                values = values.filter(value__gt=params[0])
-            elif operator == 'lt':
-                values = values.filter(value__lt=params[0])
-            values = values\
-                .select_related('variable')\
-                .select_related('society__language__family') \
-                .select_related('society__language__iso_code') \
-                .select_related('society__source')
-            # get the societies from the values
-            for value in values:
-                result_set.add_environmental(value.society, value.variable, value)
+        for varid, criteria in groupby(
+            sorted(query_dict['e'], key=lambda c: c[0]),
+            key=lambda x: x[0]
+        ):
+            alias = 'ev%s' % varid
+            sql_joins.append((
+                "environmentalvalue",
+                alias,
+                "{0}.society_id = s.id AND {0}.variable_id = {1}".format(alias, int(varid))))
+
+            for varid, operator, params in criteria:
+                params = map(float, params)
+                if operator == 'inrange':
+                    sql_where.append("{0}.value >= {1:f} AND {0}.value <= {2:f}".format(alias, params[0], params[1]))
+                elif operator == 'outrange':
+                    sql_where.append("{0}.value >= {1:f} AND {0}.value <= {2:f}".format(alias, params[1], params[0]))
+                elif operator == 'gt':
+                    sql_where.append("{0}.value >= {1:f}".format(alias, params[0]))
+                elif operator == 'lt':
+                    sql_where.append("{0}.value <= {1:f}".format(alias, params[0]))
+
+        for variable in models.EnvironmentalVariable.objects.filter(id__in=[x[0] for x in query_dict['e']]):
+            result_set.environmental_variables.add(variable)
 
     if 'p' in query_dict:
-        criteria.append(serializers.SEARCH_GEOGRAPHIC)
-        for society in models.Society.objects\
-                .filter(region_id__in=query_dict['p'])\
-                .select_related(
-                    'region',
-                    'language__family',
-                    'language__iso_code')\
-                .prefetch_related('source').all():
-            result_set.add_geographic_region(society, society.region)
+        sql_joins.append(('geographicregion', 'r', 'r.id = s.region_id'))
+        sql_where.append('r.id IN %s' % id_array(query_dict['p']))
+        for region in models.GeographicRegion.objects.filter(id__in=query_dict['p']):
+            result_set.geographic_regions.add(region)
+
+    if sql_where:
+        cursor = connection.cursor()
+        sql = "select distinct s.id from dplace_app_society as s %s where %s" % (
+            ' '.join('join dplace_app_%s as %s on %s' % t for t in sql_joins),
+            ' AND '.join(sql_where))
+        cursor.execute(sql)
+        soc_ids = [r[0] for r in cursor.fetchall()]
+    else:
+        soc_ids = []
+
+    soc_query = models.Society.objects.filter(id__in=soc_ids)\
+        .select_related('source', 'language__family', 'language__iso_code', 'region')
+    if result_set.geographic_regions:
+        soc_query = soc_query.select_related('region')
+    if result_set.variable_descriptions:
+        soc_query = soc_query.prefetch_related(Prefetch(
+            'culturalvalue_set',
+            to_attr='selected_cvalues',
+            queryset=models.CulturalValue.objects
+            # FIXME: this selects possibly too many values, in case there are multiple
+            # values for the same variable, not all of them matching the criteria.
+            .filter(variable_id__in=[v.variable.id for v in result_set.variable_descriptions])
+            .prefetch_related('references')))
+    if result_set.environmental_variables:
+        soc_query = soc_query.prefetch_related(Prefetch(
+            'environmentalvalue_set',
+            to_attr='selected_evalues',
+            queryset=models.EnvironmentalValue.objects.filter(
+                variable_id__in=[v.id for v in result_set.environmental_variables])))
+
+    for i, soc in enumerate(soc_query):
+        soc_result = serializers.SocietyResult(soc)
+        if result_set.variable_descriptions:
+            for cval in soc.selected_cvalues:
+                soc_result.variable_coded_values.add(cval)
+        if result_set.environmental_variables:
+            for eval in soc.selected_evalues:
+                soc_result.environmental_values.add(eval)
+        result_set.societies.add(soc_result)
 
     log.info('mid 1: %s' % (time() - _s,))
 
-    # Filter the results to those that matched all criteria
-    result_set.finalize(criteria)
-    log.info('mid 2: %s' % (time() - _s,))
-
     # search for language trees
-    soc_ids = [s.society.id for s in result_set.societies]
     labels = models.LanguageTreeLabels.objects.filter(societies__id__in=soc_ids).all()
     log.info('mid 3: %s' % (time() - _s,))
 

--- a/dplace_app/renderers.py
+++ b/dplace_app/renderers.py
@@ -119,12 +119,9 @@ class DPLACECSVResults(object):
                 row['Glottolog language/dialect id'] = ""
                 row['Language family'] = ""
             
-            # geographic - only one
-            geographic_regions = item['geographic_regions']
-            if len(geographic_regions) == 1:
-                geographic_region = geographic_regions[0]
-                row['Continent'] = geographic_region['continent']
-                row['Region name'] = geographic_region['region_nam']
+            if society['region']:
+                row['Continent'] = society['region']['continent']
+                row['Region name'] = society['region']['region_nam']
 
             # cultural
             cultural_trait_values = item['variable_coded_values']

--- a/dplace_app/serializers.py
+++ b/dplace_app/serializers.py
@@ -160,18 +160,26 @@ class SocietySerializer(serializers.ModelSerializer):
         )
 
 
-class TreeSocietySerializer(serializers.ModelSerializer):
-    class Meta(object):
-        model = models.Society
-        fields = ('id', 'ext_id', 'name')
-
-
 class GeographicRegionSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = models.GeographicRegion
         fields = (
             'id', 'level_2_re', 'count', 'region_nam', 'continent', 'tdwg_code'
         )
+
+
+class SocietyWithRegionSerializer(SocietySerializer):
+    region = GeographicRegionSerializer()
+
+    def __init__(self):
+        super(SocietyWithRegionSerializer, self).__init__()
+        self.Meta.fields = list(SocietySerializer.Meta.fields) + ['region']
+
+
+class TreeSocietySerializer(serializers.ModelSerializer):
+    class Meta(object):
+        model = models.Society
+        fields = ('id', 'ext_id', 'name')
 
 
 class LanguageTreeLabelsSequenceSerializer(serializers.HyperlinkedModelSerializer):
@@ -190,6 +198,7 @@ class LanguageTreeLabelsSerializer(serializers.ModelSerializer):
         model = models.LanguageTreeLabels
         fields = ('id', 'languageTree', 'label', 'language', 'societies')
 
+
 class LanguageTreeSerializer(serializers.ModelSerializer):
     taxa = LanguageTreeLabelsSerializer(many=True)
 
@@ -197,7 +206,6 @@ class LanguageTreeSerializer(serializers.ModelSerializer):
         model = models.LanguageTree
         fields = ('id', 'name', 'taxa', 'newick_string')
         
-
 
 class SocietyResult(object):
     """
@@ -207,33 +215,9 @@ class SocietyResult(object):
         self.society = society
         self.variable_coded_values = set()
         self.environmental_values = set()
-        self.languages = set()
-        self.geographic_regions = set()
 
-    def add_variable_coded_value(self, variable_coded_value):
-        self.variable_coded_values.add(variable_coded_value)
-
-    def add_environmental_value(self, environmental_value):
-        self.environmental_values.add(environmental_value)
-
-    def add_language(self, language):
-        self.languages.add(language)
-
-    def add_geographic_region(self, geographic_region):
-        self.geographic_regions.add(geographic_region)
-
-    def includes_criteria(self, criteria=None):
-        if not criteria:
-            return True
-        if SEARCH_VARIABLES in criteria and len(self.variable_coded_values) == 0:
-            return False
-        if SEARCH_ENVIRONMENTAL in criteria and len(self.environmental_values) == 0:
-            return False
-        if SEARCH_LANGUAGE in criteria and len(self.languages) == 0:
-            return False
-        if SEARCH_GEOGRAPHIC in criteria and len(self.geographic_regions) == 0:
-            return False
-        return True
+    def __eq__(self, other):
+        return self.society.id == other.society.id
 
 
 class VariableCode(object):
@@ -244,6 +228,9 @@ class VariableCode(object):
         self.codes = codes
         self.variable = variable
 
+    def __eq__(self, other):
+        return self.variable.id == other.variable.id
+
 
 class SocietyResultSet(object):
     """
@@ -252,50 +239,13 @@ class SocietyResultSet(object):
     """
 
     def __init__(self):
-        # Use a dictionary to map society_id -> SocietyResult
-        self._society_results = dict()
-        self._codes = dict()
-        self.societies = None  # not valid until finalize() is called
+        self.societies = set()
         # These are the column headers in the search results
-        self.variable_descriptions = None
+        self.variable_descriptions = set()
         self.environmental_variables = set()
         self.languages = set()
         self.geographic_regions = set()
         self.language_trees = set()
-
-    def _get_society_result(self, society):
-        if society.id not in self._society_results.keys():
-            self._society_results[society.id] = SocietyResult(society)
-        return self._society_results[society.id]
-        
-    def add_code(self, codes, variable):
-        if variable.id not in self._codes.keys():
-            self._codes[variable.id] = VariableCode(codes, variable)
-
-    def add_cultural(self, society, description, codes, value):
-        self._get_society_result(society).add_variable_coded_value(value)
-        self.add_code(codes, description)
-        
-    def add_environmental(self, society, variable, value):
-        self.environmental_variables.add(variable)
-        self._get_society_result(society).add_environmental_value(value)
-
-    def add_language(self, society, language):
-        self.languages.add(language)
-        self._get_society_result(society).add_language(language)
-
-    def add_geographic_region(self, society, region):
-        self.geographic_regions.add(region)
-        self._get_society_result(society).add_geographic_region(region)
-   
-    def add_language_tree(self, language_tree):
-        self.language_trees.add(language_tree)
-    
-    def finalize(self, criteria):
-        self.societies = [
-            x for x in self._society_results.values() if x.includes_criteria(criteria)
-        ]
-        self.variable_descriptions = [x for x in self._codes.values()]
 
 
 class VariableCodeSerializer(serializers.Serializer):
@@ -305,11 +255,9 @@ class VariableCodeSerializer(serializers.Serializer):
 
 class SocietyResultSerializer(serializers.Serializer):
     "Serializer for the SocietyResult object"
-    society = SocietySerializer()
+    society = SocietyWithRegionSerializer()
     variable_coded_values = CulturalValueSerializer(many=True)
     environmental_values = EnvironmentalValueSerializer(many=True)
-    languages = LanguageSerializer(many=True)
-    geographic_regions = GeographicRegionSerializer(many=True)
 
 
 class SocietyResultSetSerializer(serializers.Serializer):

--- a/dplace_app/static/js/colorMapService.js
+++ b/dplace_app/static/js/colorMapService.js
@@ -112,15 +112,13 @@ function ColorMapService() {
         }   
         for (var i = 0; i < results.societies.length; i++) {
             var society = results.societies[i];
-            if (society.geographic_regions) {
-                for (var j = 0; j < society.geographic_regions.length; j++) {
-                    code = results.geographic_regions.map(function(a) { return a.tdwg_code; }).indexOf(society.geographic_regions[j].tdwg_code);
-                    if (code != -1)
-                        var color = this.mapColor(code, results.geographic_regions.length);
-                    else
-                        var color = this.mapColor(society.geographic_regions[j].tdwg_code, results.geographic_regions.length);
-                    colors[society.society.id] = color;
-                }
+            if (society.society.region) {
+                code = results.geographic_regions.map(function(a) { return a.tdwg_code; }).indexOf(society.society.region.tdwg_code);
+                if (code != -1)
+                    var color = this.mapColor(code, results.geographic_regions.length);
+                else
+                    var color = this.mapColor(society.society.region.tdwg_code, results.geographic_regions.length);
+                colors[society.society.id] = color;
             }
             
             if (results.languages.length > 0 && society.environmental_values.length == 0 && society.variable_coded_values.length == 0) {        
@@ -130,7 +128,6 @@ function ColorMapService() {
                 else
                     var color = this.mapColor(society.society.language.family.id, results.classifications.length);
                 colors[society.society.id] = color;
-                
             }
             
             for (var j = 0; j < society.environmental_values.length; j++) {

--- a/dplace_app/static/js/controllers/search.js
+++ b/dplace_app/static/js/controllers/search.js
@@ -213,8 +213,8 @@ function SearchCtrl($scope, $window, colorMapService, searchModelService, FindSo
             $scope.searchModel.results.classifications = [];
             added = [];
             for (var i = 0; i < $scope.searchModel.results.societies.length; i++) {
-                for (var s = 0; s < $scope.searchModel.results.societies[i].languages.length; s++) {
-                    language_family = $scope.searchModel.results.societies[i].languages[s].family;
+                if ($scope.searchModel.results.societies[i].society.language) {
+                    language_family = $scope.searchModel.results.societies[i].society.language.family;
                     if (added.indexOf(language_family.id) == -1) { 
                         $scope.searchModel.results.classifications.push(language_family);       
                         added.push(language_family.id);

--- a/dplace_app/static/js/directives.js
+++ b/dplace_app/static/js/directives.js
@@ -39,17 +39,15 @@ angular.module('languagePhylogenyDirective', [])
                     if (!variable) {
                         if (!global) return;
                         if (scope.query.l) {
-                            for (var i = 0; i < society.languages.length; i++) {
+                            if (society.society.language) {
 
                                 selected.append("svg:circle")
                                     .attr("r", 4.5)
                                     .attr("stroke", "#000")
                                     .attr("stroke-width", "0.5")
                                     .attr("fill", function(n) {
-                                        value = results.classifications.map(function(l) { return l.id; }).indexOf(society.languages[i].family.id);
-                                        rgb = colorMapService.mapColor(value, results.classifications.length);
-                                        return rgb;
-                                        
+                                        value = results.classifications.map(function(l) { return l.id; }).indexOf(society.society.language.family.id);
+                                        return colorMapService.mapColor(value, results.classifications.length);
                                     })
                                     .on("mouseover", function() {
                                          d3.select("body").append("div")
@@ -63,19 +61,16 @@ angular.module('languagePhylogenyDirective', [])
                                     .on("mouseout", function() {
                                         d3.select(".tree-tooltip").remove();
                                     });
-                                
                             }
-                        
                         } else if (scope.query.p) {
-                            for (var i = 0; i < society.geographic_regions.length; i++) {
+                            if (society.society.region) {
                                 selected.append("svg:circle")
                                     .attr("r", 4.5)
                                     .attr("stroke", "#000")
                                     .attr("stroke-width", "0.5")
                                     .attr("fill", function(n) {
-                                        value = results.geographic_regions.map(function(g) { return g.tdwg_code; }).indexOf(society.geographic_regions[i].tdwg_code);
-                                        rgb = colorMapService.mapColor(value, results.geographic_regions.length);
-                                        return rgb;
+                                        value = results.geographic_regions.map(function(g) { return g.tdwg_code; }).indexOf(society.society.region.tdwg_code);
+                                        return colorMapService.mapColor(value, results.geographic_regions.length);
                                     })
                                     .on("mouseover", function() {
                                          d3.select("body").append("div")

--- a/dplace_app/static/js/filters.js
+++ b/dplace_app/static/js/filters.js
@@ -111,10 +111,12 @@ angular.module('dplaceFilters', [])
         };
     })
     .filter('formatLanguage', function () {
-        return function(values) {
-            return values.map( function(language) {
+        return function(language) {
+            if (language == null){
+                return '';
+            } else {
                 return language.family.name;
-            }).join('; ');
+            }
         };
     })
     .filter('formatLanguageTrees', function () {
@@ -147,9 +149,11 @@ angular.module('dplaceFilters', [])
         };
     })
     .filter('formatGeographicRegion', function () {
-        return function(values) {
-            return values.map( function(region) {
+        return function(region) {
+            if (region == null) {
+                return '';
+            } else {
                 return region.region_nam;
-            }).join(',');
+            }
         };
     });

--- a/dplace_app/static/partials/societies/table.html
+++ b/dplace_app/static/partials/societies/table.html
@@ -45,10 +45,14 @@
                 </div>
                 
             <td ng-show="results.languages">
-                {{ society_result.languages | formatLanguage}}
+                <span ng-hide="society_result.society.language == null">
+                    {{ society_result.society.language | formatLanguage}}
+                </span>
             </td>
             <td ng-show="results.geographic_regions">
-                {{ society_result.geographic_regions | formatGeographicRegion}}
+                <span ng-hide="society_result.society.region == null">
+                    {{ society_result.society.region | formatGeographicRegion}}
+                </span>
             </td>
         </tr>
     </table>

--- a/dplace_app/tests/test_colorMapService.js
+++ b/dplace_app/tests/test_colorMapService.js
@@ -57,8 +57,8 @@ describe('Color Map Service Testing', function() {
             'tdwg_code': 24
         };
 
-       society.geographic_regions.push(geographic_region);
-       mockResults.geographic_regions.push(geographic_region);
+        society.society.region = geographic_region;
+        mockResults.geographic_regions.push(geographic_region);
         mockResults.societies.push(society);
         var map = mockColorService.generateColorMap(mockResults);
         expect(map[society.society.id]).toBe('rgb(255,0,0)');

--- a/dplace_app/tests/test_serializers.py
+++ b/dplace_app/tests/test_serializers.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
-from dplace_app import models
-from dplace_app.serializers import Legend, SocietyResult
+from dplace_app.serializers import Legend
 
 # much of the testing of serializers is done in test_api, this is here to catch the
 # remainder of the unexposed/untested code.
@@ -13,35 +12,3 @@ class LegendTestCase(TestCase):
         
     def test_svg(self):
         assert Legend('name', 'svg').svg == 'svg'
-
-
-class SocietyResultTestCase(TestCase):
-    """Tests for SocietyResult"""
-    def setUp(self):
-        self.source = models.Source.objects.create(
-            year='2016',
-            author='Simon Greenhill',
-            reference='Greenhill (2016). Title.',
-            name='EA Test Dataset'
-        )
-        self.language = models.Language.objects.create(
-            name='language1',
-            glotto_code='aaaa1234',
-        )
-        self.society = models.Society.objects.create(
-            ext_id='society1',
-            xd_id='xd1',
-            name='Society1',
-            source=self.source,
-            language=self.language,
-            focal_year='2016',
-            alternate_names='Society'
-        )
-        self.SR = SocietyResult(self.society)
-        
-    def test_includes_criteria(self):
-        assert self.SR.includes_criteria() == True
-        assert self.SR.includes_criteria('l') == False
-        assert self.SR.includes_criteria('e') == False
-        assert self.SR.includes_criteria('v') == False
-        assert self.SR.includes_criteria('g') == False


### PR DESCRIPTION
This PR provides a refactored society search, which doesn't incur additional DB queries when search criteria (of the same type) are added. To make this feasibke in a simple way, search behaviour has been altered such that result sets for individual criteria are now intersected rather than unioned.

Note that this approach also leads to a significant simplification of the process of putting together search results; the somewhat opaque functionality of `SocietyResultSet` has largely been done away with.