### PR TITLE
Making search URLs cleaner for cultural search

### DIFF
--- a/dplace_app/api_views.py
+++ b/dplace_app/api_views.py
@@ -220,6 +220,8 @@ def result_set_from_query_dict(query_dict):
             result_set.languages.add(lang)
 
     if 'c' in query_dict:
+        f = open('text.txt', 'w')
+        f.write(query_dict['c'][0].split('-')[0])
         variables = {
             v.id: v for v in models.CulturalVariable.objects
             .filter(id__in=[int(x.split('-')[0]) for x in query_dict['c']])

--- a/dplace_app/api_views.py
+++ b/dplace_app/api_views.py
@@ -220,8 +220,6 @@ def result_set_from_query_dict(query_dict):
             result_set.languages.add(lang)
 
     if 'c' in query_dict:
-        f = open('text.txt', 'w')
-        f.write(query_dict['c'][0].split('-')[0])
         variables = {
             v.id: v for v in models.CulturalVariable.objects
             .filter(id__in=[int(x.split('-')[0]) for x in query_dict['c']])

--- a/dplace_app/static/js/controllers/app.js
+++ b/dplace_app/static/js/controllers/app.js
@@ -21,22 +21,8 @@ function AppCtrl($scope, $location, $http, searchModelService) {
         $location.path('/societies');
         var queryObject = $scope.model.getQuery();
         for (var key in queryObject) {
-            if (key == 'c') {
-                queryString = "["
-                for (var v = 0; v < queryObject[key].length; v++) {
-                    if (queryObject[key][v].id)
-                        queryString += queryObject[key][v].variable + '-' + queryObject[key][v].id;
-                    else {
-                        queryString += queryObject[key][v].variable + '-' + queryObject[key][v].min + '-' + queryObject[key][v].max;
-                    }
-                    if (v < queryObject[key].length-1)
-                        queryString += ',';
-                }
-                queryString += "]"
-                $location.search(key, queryString);
-            } else {
-                $location.search(key, JSON.stringify(queryObject[key]));
-            }
+            $location.search(key, JSON.stringify(queryObject[key]));
+            
         }
     };
     

--- a/dplace_app/static/js/controllers/search.js
+++ b/dplace_app/static/js/controllers/search.js
@@ -226,15 +226,15 @@ function SearchCtrl($scope, $window, $location, colorMapService, searchModelServ
                 if (codes.length > 0) {
                     searchQuery['c'] = [];
                     for (i = 0; i < codes.length; i++) {
-                        pruned = {variable: codes[i].variable};
+                        pruned = codes[i].variable;
                         if ('id' in codes[i]) {
-                            pruned['id'] = codes[i].id;
+                            pruned += '-' + codes[i].id;
                         }
                         if ('min' in codes[i]) {
-                            pruned['min'] = codes[i].min;
+                            pruned += '-' + codes[i].min;
                         }
                         if ('max' in codes[i]) {
-                            pruned['max'] = codes[i].max;
+                            pruned += '-' + codes[i].max;
                         }
                         searchQuery['c'].push(pruned);
                     }

--- a/dplace_app/static/js/controllers/societies.js
+++ b/dplace_app/static/js/controllers/societies.js
@@ -57,31 +57,7 @@ function SocietiesCtrl($scope, $location, $timeout, $http, searchModelService, c
         var queryObject = $location.search();
         var by_name = false;
         for (var key in queryObject) {
-            if (key == 'c') {
-                queryString = queryObject[key].replace("[", "").replace("]","").split(",");
-                to_search = [];
-                for (var v = 0; v < queryString.length; v++) {
-                    array = queryString[v].split("-");
-                    if (array.length == 3) { //continuous variable
-                        if (array[1] == 'undefined') {
-                            to_search.push({'variable': parseInt(array[0])});
-                        } else {
-                            to_search.push({
-                                'variable': parseInt(array[0]),
-                                'min': parseInt(array[1]),
-                                'max': parseInt(array[2])
-                            })
-                        }
-                        
-                    } else {
-                        to_search.push({
-                            'variable': parseInt(array[0]),
-                            'id': parseInt(array[1])
-                        });
-                    }
-                }
-                queryObject[key] = to_search;
-            } else if (key == 'name') {
+            if (key == 'name') {
                  by_name = true;
             } else {
                 queryObject[key] = JSON.parse(queryObject[key]);

--- a/dplace_app/static/js/searchModelService.js
+++ b/dplace_app/static/js/searchModelService.js
@@ -37,18 +37,27 @@ function SearchModelService(VariableCategory, GeographicRegion, EnvironmentalCat
                 else return 0;
             });
         }
-        
+            console.log(results.variable_descriptions);
+
         for (var i = 0; i < results.variable_descriptions.length; i++) {
             if (results.variable_descriptions[i].variable.data_type.toUpperCase() == 'CONTINUOUS') {
-                codes = query.c.filter(function(code) { return code.variable == results.variable_descriptions[i].variable.id; });
+                codes = query.c.filter(function(code) { 
+                    try {
+                        return parseInt(code.split('-')[0]) == results.variable_descriptions[i].variable.id; 
+                    } catch(err) { 
+                        return code == results.variable_descriptions[i].variable.id; 
+                    }
+                });
                 var min;
                 var max = 0;
                 codes.forEach(function(c_var) {
-                    if (!min) min = c_var.min;
+                    if ((''+c_var).split('-').length == 1) return;
+                    
+                    if (!min) min = parseFloat(c_var.split('-')[1]);
                     else {
-                        if (c_var.min < min) min = c_var.min;
+                        if (c_var.min < min) min = parseFloat(c_var.split('-')[1]);
                     }
-                    if (c_var.max > max) max = c_var.max;
+                    if (c_var.max > max) max = parseFloat(c_var.split('-')[2]);
                 });
                 results.variable_descriptions[i].variable['min'] = min.toFixed(2);
                 results.variable_descriptions[i].variable['max'] = max.toFixed(2);


### PR DESCRIPTION
Not sure about this...

I think in the future it should be label-code, like EA001-1, EA001-2 etc. Right now it uses IDs, which are meaningless to the user. I haven't changed that yet because it requires bigger changes to the api_views for society search.