### PR TITLE
Revert back since issue is a front-end problem

### DIFF
--- a/dplace_app/static/js/controllers/app.js
+++ b/dplace_app/static/js/controllers/app.js
@@ -20,9 +20,13 @@ function AppCtrl($scope, $location, $http, searchModelService) {
     $scope.switchToResults = function() {
         $location.path('/societies');
         var queryObject = $scope.model.getQuery();
-        for (var key in queryObject) {
-            $location.search(key, JSON.stringify(queryObject[key]));
-            
+        var key, val;
+        for (key in queryObject) {
+            val = queryObject[key];
+            if (key != 'name') {
+                val = JSON.stringify(val);
+            }
+            $location.search(key, val);
         }
     };
     

--- a/dplace_app/static/js/controllers/search.js
+++ b/dplace_app/static/js/controllers/search.js
@@ -293,7 +293,7 @@ function SearchCtrl($scope, $window, $location, colorMapService, searchModelServ
         $scope.searchSocieties();
 
     };
-    
+
     // resets this object state and the search query.
     $scope.resetSearch = function() {
 		$scope.errors = "";

--- a/dplace_app/tests/test_api.py
+++ b/dplace_app/tests/test_api.py
@@ -350,7 +350,7 @@ class Test(APITestCase):
                 self.society_in_results(self.get(Society, i), response))
 
     def test_find_society_by_name(self):
-        response = self.get_results(no_escape=True, name=[json.dumps('Söciety1')])
+        response = self.get_results(no_escape=True, name=['Söciety1'])
         for i, assertion in [(1, self.assertTrue), (2, self.assertFalse)]:
             assertion(self.society_in_results(self.get(Society, i), response))
 


### PR DESCRIPTION
When switching to the Results tab the front-end angular code issues
a second search request (in the case of society-by-name search).
This shouldn't happen. The issue at hand was due to the front-end
sending the second query encoded differently. This has been fixed
with this commit, but the bigger issue still is unsolved.