### PR TITLE
remove api-auth

### DIFF
--- a/dplace_app/urls.py
+++ b/dplace_app/urls.py
@@ -62,7 +62,6 @@ urlpatterns = [
     url(r'^download$', views.download_file, name='download'),
     url(r'^angular/$', views.angular, name='angular'),
     # API
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^api/v1/', include(router.urls)),
     url(r'^api/v1/find_societies', api_views.find_societies, name='find_societies'),
     url(r'^api/v1/min_and_max', api_views.get_min_and_max, name="min_and_max"),


### PR DESCRIPTION
Django 1.11 raises a warning:

```
?: (urls.W005) URL namespace 'rest_framework' isn't unique. You may not be able to reverse all URLs in this namespace
```

... The only way I can see to silence this is to remove the below line from urls.py. This means that the API will no longer allow people to login to the API. As far as I know we were not using that ability anyway. Looking at the [django-rest-framework](http://www.django-rest-framework.org/tutorial/4-authentication-and-permissions/#adding-login-to-the-browsable-api) documentation I can only see that this is used to add documentation and code-snippets to the API? (can @Bibiko or @stefelisabeth or @xrotwang confirm?)

Either way, without this line the tests pass, and in the interests of fewer moving parts (especially ones that have logins/etc attached), I'd vote that we should remove it anyway.