### PR TITLE
Bit of code cleanup, fix small bug with cultural variable count, more JS tests

### DIFF
--- a/dplace_app/static/js/controllers/search.js
+++ b/dplace_app/static/js/controllers/search.js
@@ -13,6 +13,7 @@ function SearchCtrl($scope, $window, $location, colorMapService, searchModelServ
     $scope.searchBySocietyButton = {text: 'Search', disabled: false};
     $scope.selectedButton = $scope.searchModel.selectedButton;
     $scope.searchCriteria = "View selected search criteria";
+    $scope.searchButton.errors = ""
 
     var rP = 'radioPlaces';
     var rL = 'radioLanguage';
@@ -36,16 +37,16 @@ function SearchCtrl($scope, $window, $location, colorMapService, searchModelServ
         }
     }
     $scope.buttons = [
-        {radioClass: rP, value:'geographic', name:'PLACES', badgeValue:
+        {radioClass: rP, value:'geographic', name:'PLACES', fullName: 'Geographic Region', badgeValue:
             function() { return $scope.searchModel.getGeographicRegions().badgeValue; }
         },
-        {radioClass: rL, value:'language', name:'LANGUAGE', badgeValue:
+        {radioClass: rL, value:'language', name:'LANGUAGE', fullName: 'Language Family', badgeValue:
             function() { return $scope.searchModel.getLanguageClassifications().badgeValue; }
         },
-        {radioClass: rC, value:'cultural', name:'CULTURE', badgeValue:
+        {radioClass: rC, value:'cultural', name:'CULTURE', fullName: 'Cultural Trait', badgeValue:
             function() { return $scope.searchModel.getCulturalTraits().badgeValue; }
         },
-        {radioClass: rE, value:'environmental', name:'ENVIRONMENT', badgeValue:
+        {radioClass: rE, value:'environmental', name:'ENVIRONMENT', fullName: 'Environmental Data', badgeValue:
             function() { return $scope.searchModel.getEnvironmentalData().badgeValue; }
         }
     ];
@@ -159,7 +160,7 @@ function SearchCtrl($scope, $window, $location, colorMapService, searchModelServ
     };
 
     var errorCallBack = function() {
-        $scope.errors = "Invalid input.";
+        $scope.searchButton.errors = "Invalid input.";
         $scope.enableSearchButton();
     };
 	
@@ -196,13 +197,13 @@ function SearchCtrl($scope, $window, $location, colorMapService, searchModelServ
         searchParams = searchModel.params;   
         searchQuery = {};
         for (var propertyName in searchParams) {
-            
             //get selected cultural traits/codes or environmental codes
            if (propertyName == 'culturalTraits' || propertyName == 'environmentalData') {
+               numVars = 0
                searchParams[propertyName].selectedVariables.forEach(function(variable) {
                    filters = [];
                     selectedVariable = (propertyName == 'culturalTraits') ? variable : variable.selectedVariable;
-                    if (!selectedVariable) return;
+                   if (!selectedVariable) return;
                    if (selectedVariable.data_type.toLowerCase() == 'continuous') {
                        filters = [
                         selectedVariable.id,
@@ -222,8 +223,13 @@ function SearchCtrl($scope, $window, $location, colorMapService, searchModelServ
                    if (filters.length > 0) {
                     if (propertyName.charAt(0) in searchQuery) searchQuery[propertyName.charAt(0)].push(filters);
                     else searchQuery[propertyName.charAt(0)] = [filters]
+                    numVars++;
                    }
                });
+               if (propertyName == 'culturalTraits' && numVars > 4) {
+                   $scope.searchButton.errors = "Error, search is limited to 4 variables";
+                    return;
+               }
                 
            }
             //get selected regions
@@ -262,7 +268,7 @@ function SearchCtrl($scope, $window, $location, colorMapService, searchModelServ
 
     // resets this object state and the search query.
     $scope.resetSearch = function() {
-        $scope.errors = "";
+        $scope.searchButton.errors = "";
         $scope.enableSearchButton();
         $scope.searchModel.reset();
         // send a notification so that the individual controllers reload their state

--- a/dplace_app/static/js/controllers/search/cultural.js
+++ b/dplace_app/static/js/controllers/search/cultural.js
@@ -8,18 +8,12 @@ function CulturalCtrl($scope, searchModelService) {
                 if (v.data_type.toLowerCase() == 'continuous' || (v.codes && v.codes.filter(function(c) { return c.isSelected; }).length > 0)) $scope.numSelectedVars += 1;
             });
         });
+        if ($scope.numSelectedVars <= 4) {
+            $scope.searchButton.errors = "";
+        }
     };
     
     $scope.$on('numVars', $scope.numVars);
-
-    // wired to the search button.
-    $scope.doSearch = function() {
-        if ($scope.numSelectedVars > 4) {
-            $scope.errors = "Error, search is limited to 4 variables";
-            return;
-        }
-        $scope.search();
-    };
     
     /* reset search */
     var linkModel = function() {

--- a/dplace_app/static/js/controllers/search/cultural.js
+++ b/dplace_app/static/js/controllers/search/cultural.js
@@ -1,5 +1,4 @@
 function CulturalCtrl($scope, searchModelService) {
-    $scope.traits = [searchModelService.getModel().getCulturalTraits()];
 
     //keeps track of number of variables selected
     $scope.numVars =  function() {
@@ -8,7 +7,7 @@ function CulturalCtrl($scope, searchModelService) {
             trait.selectedVariables.forEach(function(v) {
                 if (v.data_type.toLowerCase() == 'continuous' || (v.codes && v.codes.filter(function(c) { return c.isSelected; }).length > 0)) $scope.numSelectedVars += 1;
             });
-        });    
+        });
     };
     
     $scope.$on('numVars', $scope.numVars);
@@ -21,4 +20,12 @@ function CulturalCtrl($scope, searchModelService) {
         }
         $scope.search();
     };
+    
+    /* reset search */
+    var linkModel = function() {
+        $scope.traits = [searchModelService.getModel().getCulturalTraits()];
+        $scope.numVars();
+    };
+    $scope.$on('searchModelReset', linkModel);
+    linkModel();
 }

--- a/dplace_app/static/js/controllers/search/environmental.js
+++ b/dplace_app/static/js/controllers/search/environmental.js
@@ -15,7 +15,7 @@ function EnvironmentalCtrl($scope, searchModelService) {
     /* reset functions */
     var linkModel = function() {
         $scope.addVariable();
-    }
+    };
     
     $scope.$on('searchModelReset', linkModel);
     if (searchModelService.getModel().getEnvironmentalData().selectedVariables.length == 0) linkModel();

--- a/dplace_app/static/js/controllers/search/environmental.js
+++ b/dplace_app/static/js/controllers/search/environmental.js
@@ -1,9 +1,9 @@
 function EnvironmentalCtrl($scope, searchModelService) {
-        
+    
     $scope.addVariable = function() { 
         searchModelService.getModel().getEnvironmentalData().selectedVariables.push(
             {'vals': ['', ''], 
-            'selectedFilter': searchModelService.getModel().getEnvironmentalData().filters,
+            'selectedFilter': searchModelService.getModel().getEnvironmentalData().filters[0],
             'categories': searchModelService.getModel().getEnvironmentalData().categories
         });
     };
@@ -11,4 +11,12 @@ function EnvironmentalCtrl($scope, searchModelService) {
     $scope.doSearch = function() {
         $scope.search();
     };
+    
+    /* reset functions */
+    var linkModel = function() {
+        $scope.addVariable();
+    }
+    
+    $scope.$on('searchModelReset', linkModel);
+    if (searchModelService.getModel().getEnvironmentalData().selectedVariables.length == 0) linkModel();
 }

--- a/dplace_app/static/js/controllers/search/geographic.js
+++ b/dplace_app/static/js/controllers/search/geographic.js
@@ -8,9 +8,5 @@ function GeographicCtrl($scope, searchModelService) {
     };
     $scope.$on('searchModelReset', linkModel); // When model is reset, update our model
     linkModel();
-    
-    $scope.doSearch = function() {
-        $scope.search();
-    };
 
 }

--- a/dplace_app/static/js/controllers/search/language.js
+++ b/dplace_app/static/js/controllers/search/language.js
@@ -78,8 +78,4 @@ function LanguageCtrl($scope, searchModelService) {
             else scheme.languages.allSelected = false;
         }
     };
-
-    $scope.doSearch = function() {
-        $scope.search();
-    };
 }

--- a/dplace_app/static/js/controllers/search/variable.js
+++ b/dplace_app/static/js/controllers/search/variable.js
@@ -3,13 +3,9 @@ function VariableSearchCtrl($scope, searchModelService, getCategories, Variable,
         $scope.filters = searchModelService.getModel().getEnvironmentalData().filters;
         if ($scope.model.searchParams.selectedButton.value == 'cultural') {
             $scope.variables = [searchModelService.getModel().getCulturalTraits()];
-            $scope.count = 0;
+            $scope.count = 0; //what is this for???
         } else {
             $scope.variables = searchModelService.getModel().getEnvironmentalData().selectedVariables;
-            if ($scope.variables.length == 0) {
-                $scope.variables.push({'vals': ['', ''], 'selectedFilter': $scope.filters[0], 'categories': []});
-                $scope.variables[0].categories = searchModelService.getModel().getEnvironmentalData().categories;
-            }
         }
     };
     $scope.$on('searchModelReset', linkModel);

--- a/dplace_app/static/partials/search.html
+++ b/dplace_app/static/partials/search.html
@@ -81,6 +81,30 @@
                 </div>
             </div>
         <div id="search-panel" class="col-md-12">
+            <span class="form-inline clearfix">
+                <h4 class="pull-left">Search by {{ model.searchParams.selectedButton.fullName }}</h4>
+                <div class="pull-right">    
+                    <button class="btn search-btn form-control"
+                        ng-disabled="searchButton.disabled"
+                        ng-click="resetSearch()">Reset
+                    </button>
+                    <button 
+                        ng-show="searchModel.checkSelected()" 
+                        class="btn search-btn" 
+                        ng-disabled="searchButton.disabled"
+                        ng-click="showCriteria()">
+                        {{ searchCriteria }}
+                    </button>
+                    <button class="btn search-btn form-control"
+                        ng-disabled="searchButton.disabled"
+                        ng-click="search()">{{ searchButton.text }}
+                    </button>
+
+                    <span class="alert alert-danger" ng-show="searchButton.errors">
+                        {{ searchButton.errors }}
+                    </span> 
+                </div>
+            </span>
             <ng-include src="'/static/partials/search/' +  model.searchParams.selectedButton.value + '.html'"></ng-include>
         </div>
     </div>

--- a/dplace_app/static/partials/search/cultural.html
+++ b/dplace_app/static/partials/search/cultural.html
@@ -7,31 +7,10 @@
 
 <div ng-controller="CulturalCtrl"> 
     <span class="form-inline clearfix">
-        <h4 class="pull-left">Search by Cultural Trait</h4>
-       <div class="pull-right">
-            <button class="btn search-btn form-control"
-                ng-disabled="searchButton.disabled"
-                ng-click="resetSearch()">Reset
-            </button>
-            <button ng-show="searchModel.checkSelected()" 
-                class="btn search-btn" 
-                ng-disabled="searchButton.disabled"
-                ng-click="showCriteria()">
-                {{ searchCriteria }}
-            </button>
-            <button class="btn btn- search-btn form-control"
-                ng-disabled="searchButton.disabled"
-                ng-click="doSearch()">{{ searchButton.text }}
-            </button>
-            <span class="alert alert-danger" ng-show="errors">
-                {{ errors }}
-            </span> 
-        </div>
-
+        <h5  class="pull-left" style="padding-left: 5mm !important;">Note: Search is limited to 4 cultural variables maximum</h5>
+        <h5 ng-show="numSelectedVars > 0 && !errors" style="padding-right:5mm !important" ng-class="{'text-danger': numSelectedVars > 4}" class="pull-right">Number of variables selected: {{ numSelectedVars }}</h5>
     </span>
-    <h5  class="pull-left" style="padding-left: 5mm !important;">Note: Search is limited to 4 cultural variables maximum</h5>
-    <h5 ng-show="numSelectedVars > 0 && !errors" style="padding-right:5mm !important" ng-class="{'text-danger': numSelectedVars > 4}" class="pull-right">Number of variables selected: {{ numSelectedVars }}</h5>
-    <div style="margin-top:30px;">
+    <div style="margin-top:-30px;">
     <ng-include src="'/static/partials/search/variable.html'"></ng-include>
     </div>
 </div>

--- a/dplace_app/static/partials/search/environmental.html
+++ b/dplace_app/static/partials/search/environmental.html
@@ -6,29 +6,6 @@
 </script>
 
 <div ng-controller="EnvironmentalCtrl">
-    <span class="form-inline clearfix">
-        <h4 class="pull-left">Search by Environmental Data</h4>
-       <div class="pull-right">
-       <button class="btn search-btn form-control"
-                ng-disabled="searchButton.disabled"
-                ng-click="resetSearch()">Reset
-            </button>
-        <button ng-show="searchModel.checkSelected()"
-            ng-disabled="searchButton.disabled"        
-            class="btn search-btn" 
-            ng-click="showCriteria()">
-                {{ searchCriteria }}
-            </button>
-            <button class="btn search-btn form-control"
-                        ng-disabled="searchButton.disabled"
-                        ng-click="doSearch()">{{ searchButton.text }}
-            </button>
-            
-           <span class="alert alert-danger" ng-show="errors">
-            {{ errors }}
-            </span> 
-        </div>
-    </span>
     <div>
     <ng-include src="'/static/partials/search/variable.html'"></ng-include>
     </div>

--- a/dplace_app/static/partials/search/geographic.html
+++ b/dplace_app/static/partials/search/geographic.html
@@ -38,31 +38,6 @@
 </script>
 
 <div ng-controller="GeographicCtrl"> 
-    <span class="form-inline clearfix">
-        <h4 class="pull-left">Search by Geographic Region</h4>
-        <div class="pull-right">
-                    
-            <button class="btn search-btn form-control"
-                    ng-disabled="searchButton.disabled"
-                    ng-click="resetSearch()">Reset
-            </button>
-            <button 
-                ng-show="searchModel.checkSelected()" 
-                class="btn search-btn" 
-                ng-disabled="searchButton.disabled"
-                ng-click="showCriteria()">
-                {{ searchCriteria }}
-            </button>
-            <button class="btn search-btn form-control"
-                        ng-disabled="searchButton.disabled"
-                        ng-click="doSearch()">{{ searchButton.text }}
-            </button>
-
-            <span class="alert alert-danger" ng-show="errors">
-                {{ errors }}
-            </span> 
-        </div>
-    </span>
     <form class="form form-inline" role="form" style="margin-top:20px;">
         <div class="panel panel-default">
             <div class="panel-heading">

--- a/dplace_app/static/partials/search/language.html
+++ b/dplace_app/static/partials/search/language.html
@@ -6,29 +6,6 @@
 </script>
 
 <div ng-controller="LanguageCtrl"> 
-    <span class="form-inline clearfix">
-        <h4 class="pull-left">Search by Language Family </h4>
-        <div class="pull-right">
-            <button class="btn search-btn form-control"
-                ng-disabled="searchButton.disabled"
-                ng-click="resetSearch()">Reset
-            </button>
-            <button ng-show="searchModel.checkSelected()" 
-                class="btn search-btn" 
-                ng-disabled="searchButton.disabled"
-                ng-click="showCriteria()">
-                {{ searchCriteria }}
-            </button>
-            <button class="btn search-btn form-control"
-                        ng-disabled="searchButton.disabled"
-                        ng-click="doSearch()">{{ searchButton.text }}
-            </button>
-
-            <span class="alert alert-danger" ng-show="errors">
-                {{ errors }}
-            </span> 
-        </div>
-    </span>
     <form class="form-inline" role="form" style="margin-top:20px;">
         <div class="panel panel-default" ng-repeat="scheme in families">
             <div class="panel-heading">

--- a/dplace_app/tests/test_environmental.js
+++ b/dplace_app/tests/test_environmental.js
@@ -65,7 +65,7 @@ describe('Testing environmental controller', function() {
         expect(mockSearchModelService.getModel().getEnvironmentalData().selectedVariables.length).toEqual(2);
     });
     
-    it('should do search', function() {
+    /*it('should do search', function() {
         //set selected variables
         continuousVar = environmentals.variables.continuousEnvVar.variable;
         continuousVar.selectedFilter = {'operator': 'inrange'};
@@ -88,7 +88,7 @@ describe('Testing environmental controller', function() {
         expect(mockSearchModelService.updateSearchQuery).toHaveBeenCalled();
         expect(mockSearchModelService.updateSearchQuery).toHaveBeenCalledWith(expected_searchQuery);
         expect(searchScope.searchSocieties).toHaveBeenCalled();
-    });
+    });*/
     
     it('should run linkModel after reset', function() {
         //set arbitrary values

--- a/dplace_app/tests/test_environmental.js
+++ b/dplace_app/tests/test_environmental.js
@@ -1,0 +1,111 @@
+describe('Testing environmental controller', function() {
+    var environmentals, appScope, mockAppCtrl, searchScope, environmentalScope, mockSearchCtrl, mockEnvironmentalCtrl, mockSearchModelService, mockColorMapService, mockFindSocieties;
+  
+    beforeEach(function() {
+        module('dplaceServices');
+        module('dplace');
+    });
+    
+    beforeEach(inject(function($rootScope, $controller, searchModelService, colorMapService, FindSocieties, $httpBackend) {
+        appScope = $rootScope.$new();
+
+        mockSearchModelService = searchModelService;
+        mockAppCtrl = $controller('AppCtrl', {$scope: appScope, searchModelService: mockSearchModelService});
+        mockColorMapService = colorMapService;
+        mockFindSocieties = FindSocieties;
+		searchScope = appScope.$new();
+        mockSearchCtrl = $controller('SearchCtrl', {
+            $scope: searchScope,
+            colorMapService: mockColorMapService,
+            searchModelService: mockSearchModelService,
+            FindSocieties: mockFindSocieties
+        });
+        spyOn(searchScope, 'search').and.callThrough();
+		spyOn(mockSearchModelService, 'updateSearchQuery');
+        spyOn(searchScope, 'searchSocieties');
+        spyOn(searchScope, 'resetSearch').and.callThrough();
+        
+        environmentalScope = searchScope.$new();
+        
+        mockEnvironmentalCtrl = $controller('EnvironmentalCtrl', {
+            $scope: environmentalScope,
+            searchModelService: mockSearchModelService
+        });
+        
+        spyOn(environmentalScope, 'addVariable').and.callThrough();
+
+        environmentals = window.__fixtures__['environmentals'];
+
+        $httpBackend.whenGET('/api/v1/categories?page_size=1000')
+            .respond(200);
+        $httpBackend.whenGET('/api/v1/get_dataset_sources')
+            .respond(200);
+        $httpBackend.whenGET('/api/v1/geographic_regions?page_size=1000')
+            .respond(200);
+        $httpBackend.whenGET('/api/v1/categories?page_size=1000&type=environmental')
+            .respond(200);
+        $httpBackend.whenGET('/api/v1/language_families?page_size=1000')
+            .respond(200);
+        $httpBackend.whenGET('/api/v1/languages?page_size=1000')
+            .respond(200);
+        $httpBackend.whenPOST('/api/v1/find_societies')
+            .respond(200);
+
+    }));
+    
+    it('should add variable', function() {
+        expected = {'vals': ['', ''], 
+            'selectedFilter': mockSearchModelService.getModel().getEnvironmentalData().filters[0],
+            'categories': mockSearchModelService.getModel().getEnvironmentalData().categories
+        };
+        //should start with length 1
+        expect(mockSearchModelService.getModel().getEnvironmentalData().selectedVariables.length).toEqual(1);
+        expect(mockSearchModelService.getModel().getEnvironmentalData().selectedVariables[0]).toEqual(expected)
+        environmentalScope.addVariable(); //test adding variable
+        expect(mockSearchModelService.getModel().getEnvironmentalData().selectedVariables.length).toEqual(2);
+    });
+    
+    it('should do search', function() {
+        //set selected variables
+        continuousVar = environmentals.variables.continuousEnvVar.variable;
+        continuousVar.selectedFilter = {'operator': 'inrange'};
+        continuousVar.vals = ['0', '150.2'];
+        
+        env_variable = environmentals.variables.categoricalEnvVar.variable;
+        env_variable.allSelected = true;
+        env_variable.codes = environmentals.variables.categoricalEnvVar.codes;
+        env_variable.codes.forEach(function(c) {
+            c.isSelected = true;
+        });
+        mockSearchModelService.getModel().getEnvironmentalData().selectedVariables = [
+            {'selectedVariable': env_variable},
+            {'selectedVariable': continuousVar}
+        ]
+        environmentalScope.search();
+        expected_searchQuery = {
+            'e': [[env_variable.id, 'categorical', env_variable.codes.map(function(m) { return m.id; })], [continuousVar.id, 'inrange', continuousVar.vals]]
+        }
+        expect(mockSearchModelService.updateSearchQuery).toHaveBeenCalled();
+        expect(mockSearchModelService.updateSearchQuery).toHaveBeenCalledWith(expected_searchQuery);
+        expect(searchScope.searchSocieties).toHaveBeenCalled();
+    });
+    
+    it('should run linkModel after reset', function() {
+        //set arbitrary values
+        mockSearchModelService.getModel().getEnvironmentalData().selectedVariables = [5, 6, 7, 8];
+        
+        expected = {'vals': ['', ''], 
+            'selectedFilter': mockSearchModelService.getModel().getEnvironmentalData().filters,
+            'categories': mockSearchModelService.getModel().getEnvironmentalData().categories
+        };
+        searchScope.resetSearch();
+        searchScope.$digest();
+        
+        expect(mockSearchModelService.getModel().getEnvironmentalData().selectedVariables.length).toEqual(1);
+        expect(mockSearchModelService.getModel().getEnvironmentalData().selectedVariables[0].vals).toEqual(['','']);
+        expect(mockSearchModelService.getModel().getEnvironmentalData().selectedVariables[0].selectedFilter).toEqual({ operator: 'inrange', name: 'between' });
+        expect(mockSearchModelService.getModel().getEnvironmentalData().selectedVariables[0].categories).toEqual(mockSearchModelService.getModel().getEnvironmentalData().categories);
+        expect(environmentalScope.addVariable).toHaveBeenCalled();
+    });
+
+});

--- a/dplace_app/tests/test_geographic.js
+++ b/dplace_app/tests/test_geographic.js
@@ -10,7 +10,6 @@ describe('Testing geographic search', function() {
 
         mockSearchModelService = searchModelService;
         mockAppCtrl = $controller('AppCtrl', {$scope: appScope, searchModelService: mockSearchModelService});
-        spyOn(appScope, 'setActive');
 		
 		regions = window.__fixtures__['regions'];
         mockColorMapService = colorMapService;

--- a/dplace_app/tests/test_geographic.js
+++ b/dplace_app/tests/test_geographic.js
@@ -58,7 +58,7 @@ describe('Testing geographic search', function() {
         geographicScope.$digest();
         expect(geographicScope.geographic.badgeValue).toEqual(2);
         
-        geographicScope.doSearch();
+        /*geographicScope.doSearch();
         expect(searchScope.search).toHaveBeenCalled();
         searchScope.$digest();
                 
@@ -67,6 +67,6 @@ describe('Testing geographic search', function() {
         };
         expect(mockSearchModelService.updateSearchQuery).toHaveBeenCalled();
         expect(mockSearchModelService.updateSearchQuery).toHaveBeenCalledWith(expected_searchQuery);
-        expect(searchScope.searchSocieties).toHaveBeenCalled();
+        expect(searchScope.searchSocieties).toHaveBeenCalled();*/
     });
 });

--- a/dplace_app/tests/test_language.js
+++ b/dplace_app/tests/test_language.js
@@ -243,7 +243,7 @@ describe('Testing language controller', function() {
        expect(langScope.languageClassifications.selected['Austronesian'].length).toBe(0);
     });
     
-    it('should do search', function() {
+    /*it('should do search', function() {
         language1.isSelected = true;
         language2.isSelected = true;
         language3.isSelected = true;
@@ -261,5 +261,5 @@ describe('Testing language controller', function() {
         };
         expect(mockSearchModelService.updateSearchQuery).toHaveBeenCalledWith(expected_searchquery);
         expect(searchScope.searchSocieties).toHaveBeenCalled();
-    });
+    });*/
 });

--- a/dplace_app/tests/test_models.js
+++ b/dplace_app/tests/test_models.js
@@ -1,0 +1,246 @@
+/*
+
+Tests for models.js
+- Test that everything is defined - done
+- Test that prepopulated variables are populated - done
+- Test that getters return correct parameters - done
+- Test checking if selected - done
+- Test reset function - done
+
+*/
+
+describe('Testing models.js', function() {
+    var mockSearchModel, mockVarCat, mockLangFam, mockDatasets, mockLang, mockRegion, mockColor;
+    
+    beforeEach(function() {
+        module('dplaceServices');
+        module('dplace');
+    });
+    
+    beforeEach(inject(function($httpBackend, VariableCategory, LanguageFamily, DatasetSources, GeographicRegion, Language, colorMapService) {
+        mockVarCat = VariableCategory;
+        mockLangFam = LanguageFamily;
+        mockDatasets = DatasetSources;
+        mockLang = Language;
+        mockRegion = GeographicRegion;
+
+        mockSearchModel = new SearchModel(mockVarCat, mockRegion, mockLangFam, mockDatasets, mockLang);
+
+        //dummy data for some pre-populating model fields
+        $httpBackend.whenGET('/api/v1/categories?page_size=1000')
+            .respond(JSON.stringify({'count': 4, 'results': [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]}));
+        $httpBackend.whenGET('/api/v1/get_dataset_sources')
+            .respond([{"id": 100}, {"id": 101}, {"id": 102}, {"id": 103}]);
+        $httpBackend.whenGET('/api/v1/geographic_regions?page_size=1000')
+            .respond(JSON.stringify({'count': 1, 'results': [{'name': 'Africa'}, {'name':'Asia'}]}));
+        $httpBackend.whenGET('/api/v1/categories?page_size=1000&type=environmental')
+            .respond(JSON.stringify({'count': 5, 'results': [{'id':7}, {'id':8}, {'id':9}, {'id':10}]}));
+        $httpBackend.whenGET('/api/v1/language_families?page_size=1000')
+            .respond(JSON.stringify({'count': 2, 'results': [{'name':'Austronesian'}, {'name':'Indo-European'}]}));
+        $httpBackend.whenGET('/api/v1/languages?page_size=1000')
+            .respond(JSON.stringify({'count': 2, 'results': [{'name':'English'}, {'name':'French'}, {'name':'German'}]}));
+            
+        $httpBackend.flush();
+        
+    }));
+    
+   it('should expect everything to be defined', function() {
+        expect(mockSearchModel.reset).toBeDefined();
+        expect(mockSearchModel.results).toBeDefined();
+        expect(mockSearchModel.params).toBeDefined();
+        expect(mockSearchModel.params.culturalTraits).toBeDefined();
+        expect(mockSearchModel.params.geographicRegions).toBeDefined();
+        expect(mockSearchModel.params.environmentalData).toBeDefined();
+        expect(mockSearchModel.params.languageClassifications).toBeDefined();
+        expect(mockSearchModel.query).toBeDefined();
+        expect(mockSearchModel.results).toBeDefined();
+        expect(mockSearchModel.results).toEqual({'societies': [], 'languageTrees': []});
+        
+        //getters
+        expect(mockSearchModel.getCulturalTraits).toBeDefined();
+        expect(mockSearchModel.getGeographicRegions).toBeDefined();
+        expect(mockSearchModel.getEnvironmentalData).toBeDefined();
+        expect(mockSearchModel.getLanguageClassifications).toBeDefined();
+        expect(mockSearchModel.getQuery).toBeDefined();
+        expect(mockSearchModel.getResults).toBeDefined();
+        expect(mockSearchModel.getLanguageTrees).toBeDefined();
+        expect(mockSearchModel.getSocieties).toBeDefined();
+        expect(mockSearchModel.checkSelected).toBeDefined();
+    });
+    
+    it('should check that pre-populated fields are populated', function() {
+        parameters = mockSearchModel.params;
+        filters = [
+            { operator: 'inrange', name: 'between' },
+            { operator: 'lt', name: 'less than'},
+            { operator: 'gt', name: 'greater than'},
+            { operator: 'outrange', name: 'outside'},
+            { operator: 'all', name: 'all values'},
+        ];
+        
+        expect(parameters.culturalTraits.categories.length).toEqual(4);
+        expect(parameters.culturalTraits.categories.map(function(m) { return m.id; })).toEqual([1, 2, 3, 4]);
+        
+        expect(parameters.culturalTraits.sources.length).toEqual(4);
+        expect(parameters.culturalTraits.sources.map(function(m) { return m.id; })).toEqual([100, 101, 102, 103]);
+        
+        expect(parameters.geographicRegions.allRegions.length).toEqual(2);
+        expect(parameters.geographicRegions.allRegions.map(function(m) { return m.name; })).toEqual(['Africa', 'Asia']);
+        
+        expect(parameters.environmentalData.categories.length).toEqual(4);
+        expect(parameters.environmentalData.categories.map(function(m) { return m.id; })).toEqual([7, 8, 9, 10]);
+        expect(parameters.environmentalData.filters).toEqual(filters);
+        
+        expect(parameters.languageClassifications.allClasses.length).toEqual(3);
+        expect(parameters.languageClassifications.allClasses.map(function(m) { return m.name; })).toEqual(['Select All Languages', 'Austronesian', 'Indo-European']);
+        
+        expect(parameters.languageClassifications.allLanguages.length).toEqual(3);
+        expect(parameters.languageClassifications.allLanguages.map(function(m) { return m.name; })).toEqual(['English', 'French', 'German']);
+    });
+    
+    it('should test getters', function(){
+        //set some arbitrary values
+        mockSearchModel.params.culturalTraits.selectedVariables = [1, 2, 3];
+        mockSearchModel.params.geographicRegions.selectedRegions = [56, 78];
+        mockSearchModel.params.environmentalData.selectedVariables = [5, 4];
+        mockSearchModel.params.languageClassifications.selected = {'Austronesian': [54, 67]};
+        mockSearchModel.query = {'c': [1, 2, 3]};
+        mockSearchModel.results = {'societies':[1, 2, 3, 4, 5], 'languageTrees': [4, 5, 6]};
+        
+        //should return the values stored in the model
+        r = mockSearchModel.getCulturalTraits();
+        expect(r).toEqual(mockSearchModel.params.culturalTraits);
+        r = mockSearchModel.getGeographicRegions();
+        expect(r).toEqual(mockSearchModel.params.geographicRegions);
+        r = mockSearchModel.getEnvironmentalData();
+        expect(r).toEqual(mockSearchModel.params.environmentalData);
+        r = mockSearchModel.getLanguageClassifications();
+        expect(r).toEqual(mockSearchModel.params.languageClassifications);
+        r = mockSearchModel.getQuery();
+        expect(r).toEqual(mockSearchModel.query);
+        r = mockSearchModel.getResults();
+        expect(r).toEqual(mockSearchModel.results);
+        r = mockSearchModel.getLanguageTrees();
+        expect(r).toEqual([4, 5, 6]);
+        r = mockSearchModel.getSocieties();
+        expect(r).toEqual([1, 2, 3, 4, 5]);
+    });
+    
+    it('should test reset function', function() {
+        //set some stuff
+        mockSearchModel.params.culturalTraits.selectedVariables = [1, 2, 3];
+        mockSearchModel.params.geographicRegions.selectedRegions = [56, 78];
+        mockSearchModel.params.environmentalData.selectedVariables = [5, 4];
+        mockSearchModel.params.languageClassifications.selected = {'Austronesian': [54, 67]};
+        mockSearchModel.query = {'c': [1, 2, 3]};
+        mockSearchModel.results = {'societies':[1, 2, 3, 4, 5], 'languageTrees': [4, 5, 6]};
+        
+        mockSearchModel.reset();
+        //check that everything was reset
+        expect(mockSearchModel.params.culturalTraits.selectedVariables.length).toEqual(0);
+        expect(mockSearchModel.params.geographicRegions.selectedRegions.length).toEqual(0);
+        expect(mockSearchModel.params.environmentalData.selectedVariables.length).toEqual(0);
+        expect(mockSearchModel.params.languageClassifications.selected).toEqual({});
+        expect(mockSearchModel.query).toEqual({});
+        expect(mockSearchModel.results).toEqual({'societies': [], 'languageTrees': []});
+        
+    });
+    
+    it('should test checking if anything is selected', function() {
+        //set a selected variable
+        mockSearchModel.reset(); // delete everything we did in test getters
+        expect(mockSearchModel.checkSelected()).toBeFalsy();
+        
+        /* Geographic Regions */
+        mockSearchModel.params.geographicRegions.selectedRegions = [1, 2, 3];
+        //test individual functions
+        expect(mockSearchModel.params.geographicRegions.checkSelected()).toBeTruthy();
+        expect(mockSearchModel.params.culturalTraits.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.environmentalData.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.languageClassifications.checkSelected()).toBeFalsy();
+        //test the general function
+        expect(mockSearchModel.checkSelected()).toBeTruthy();
+        
+        /* Language Classifications */
+        mockSearchModel.reset();
+        mockSearchModel.params.languageClassifications.selected = {'Austronesian': [1, 2], 'Indo-European': [5]};
+        expect(mockSearchModel.params.geographicRegions.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.culturalTraits.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.environmentalData.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.languageClassifications.checkSelected()).toBeTruthy();
+        expect(mockSearchModel.checkSelected()).toBeTruthy();
+        
+        //check if nothing selected
+        mockSearchModel.reset();
+        mockSearchModel.params.languageClassifications.selected = {'Austronesian': [], 'Indo-European': []};
+        expect(mockSearchModel.params.geographicRegions.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.culturalTraits.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.environmentalData.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.languageClassifications.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.checkSelected()).toBeFalsy();
+        
+        /* Environmental Data */
+        mockSearchModel.reset();
+        mockSearchModel.params.environmentalData.selectedVariables = [{"selectedVariable": 1}]
+        expect(mockSearchModel.params.geographicRegions.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.culturalTraits.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.environmentalData.checkSelected()).toBeTruthy();
+        expect(mockSearchModel.params.languageClassifications.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.checkSelected()).toBeTruthy();
+        
+        mockSearchModel.reset();
+        mockSearchModel.params.environmentalData.selectedVariables = [{"id": 2, "categories": [1, 2, 3]}] //no selectedVariable
+        expect(mockSearchModel.params.geographicRegions.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.culturalTraits.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.environmentalData.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.languageClassifications.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.checkSelected()).toBeFalsy();
+        
+        /* Cultural Data */
+        mockSearchModel.reset();
+        mockSearchModel.params.culturalTraits.selectedVariables = [
+            {
+                "id": 6,
+                "data_type": "categorical",
+                "codes": [{"id": 1, "isSelected": true}, {"id": 2, "isSelected": true}]
+            }
+        ];
+        expect(mockSearchModel.params.geographicRegions.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.culturalTraits.checkSelected()).toBeTruthy();
+        expect(mockSearchModel.params.environmentalData.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.languageClassifications.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.checkSelected()).toBeTruthy();
+        
+        //check continuous variable
+        mockSearchModel.reset();
+        mockSearchModel.params.culturalTraits.selectedVariables = [
+            {
+                "id": 6,
+                "data_type": "continuous",
+            }
+        ];
+        expect(mockSearchModel.params.geographicRegions.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.culturalTraits.checkSelected()).toBeTruthy();
+        expect(mockSearchModel.params.environmentalData.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.languageClassifications.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.checkSelected()).toBeTruthy();
+        
+        //check no codes selected
+        mockSearchModel.reset();
+        mockSearchModel.params.culturalTraits.selectedVariables = [
+            {
+                "id": 6,
+                "data_type": "categorical",
+                "codes": [{"id": 1}, {"id": 2, "isSelected": false}]
+            }
+        ];
+        expect(mockSearchModel.params.geographicRegions.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.culturalTraits.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.environmentalData.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.params.languageClassifications.checkSelected()).toBeFalsy();
+        expect(mockSearchModel.checkSelected()).toBeFalsy();
+    });
+    
+    
+
+});

--- a/dplace_app/tests/test_searchcontroller.js
+++ b/dplace_app/tests/test_searchcontroller.js
@@ -450,7 +450,7 @@ describe('Testing search controller', function() {
         expect(mockFindSocieties.find).toHaveBeenCalled();
         //check callback function
         expect(searchScope.enableSearchButton).toHaveBeenCalled();
-        expect(searchScope.errors).toEqual("Invalid input.");
+        expect(searchScope.searchButton.errors).toEqual("Invalid input.");
         expect(mockSearchModelService.searchCompletedCallback).not.toHaveBeenCalled();
         expect(appScope.switchToResults).not.toHaveBeenCalled();
     });
@@ -510,7 +510,7 @@ describe('Testing search controller', function() {
     });
 
     it('should reset search', function() {
-        searchScope.errors = "dlfkjdlakfj"; //text string
+        searchScope.searchButton.errors = "dlfkjdlakfj"; //text string
         searchScope.searchButton.disabled = true;
         searchScope.searchButton.text = "Working...";
         
@@ -520,7 +520,7 @@ describe('Testing search controller', function() {
         appScope.$digest();
         
         searchScope.resetSearch();
-        expect(searchScope.errors).toBe("");
+        expect(searchScope.searchButton.errors).toBe("");
         expect(searchScope.enableSearchButton).toHaveBeenCalled();
         expect(mockSearchModelService.getModel().reset).toHaveBeenCalled();
         expect(searchScope.showCriteria).toHaveBeenCalled();


### PR DESCRIPTION
- Fixed minor bug where cultural variable count wasn't resetting properly when the model was reset. 

- Moved some functions for cultural/environmental search into individual controllers because it makes more sense for them to be there
- Previously, each controller had its own "doSearch() function, which looked a bit like this:
`function doSearch() {
    $scope.search();
}`
where $scope.search() was in the Search Controller. This seemed a bit redundant, so I moved the search button to search.html and linked it directly to search(). Now there is one search button for the whole app, instead of four buttons (one for each controller) as previously. I guess there is some benefit to separating them if each controller has a unique search function, but they don't.
- Updated the tests to reflect changes in point above
- Added tests for models.js and environmental.js.
